### PR TITLE
feat: configurable API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,15 @@ LIST_ID=your‑list‑id
 
 At runtime the backend uses these values to obtain an access token via the client credentials grant and to talk to the Microsoft Graph API.  See `backend/sharepointClient.js` for the implementation details.  When deploying to production you should store secrets securely (e.g. Azure Key Vault) rather than committing them to source control.
 
+### API base URL
+
+The frontend looks for `VITE_API_BASE_URL` to know where the backend is running. When the variable is not set it defaults to `/api`.
+
+```bash
+# frontend/.env
+VITE_API_BASE_URL=http://localhost:5000/api
+```
+
 ## Running in production
 
 For production builds run `npm run build` in the `frontend` directory to generate a static build in `frontend/dist`.  You can then serve this folder through your preferred HTTP server (Nginx, Express, etc.).  The backend can be deployed to any Node‑capable environment; just remember to set the environment variables described above.

--- a/frontend/src/pages/SubmitPage.jsx
+++ b/frontend/src/pages/SubmitPage.jsx
@@ -1,6 +1,8 @@
-import React, { useContext, useState } from 'react';
-import axios from 'axios';
-import { ReceiptContext } from '../context/ReceiptContext.jsx';
+import React, { useContext, useState } from 'react'
+import axios from 'axios'
+import { ReceiptContext } from '../context/ReceiptContext.jsx'
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
 
 export default function SubmitPage() {
   const { receipt } = useContext(ReceiptContext);
@@ -13,7 +15,7 @@ export default function SubmitPage() {
     setError(null);
     setSuccess(false);
     try {
-      await axios.post('http://localhost:5000/api/submit', {
+      await axios.post(`${API_BASE_URL}/submit`, {
         fields: receipt.fields,
         attachments: receipt.attachments.map((file) => ({
           name: file.name,

--- a/frontend/src/pages/UploadPage.jsx
+++ b/frontend/src/pages/UploadPage.jsx
@@ -1,8 +1,10 @@
-import React, { useContext, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import axios from 'axios';
-import { ReceiptContext } from '../context/ReceiptContext.jsx';
-import FileUpload from '../components/FileUpload.jsx';
+import React, { useContext, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import axios from 'axios'
+import { ReceiptContext } from '../context/ReceiptContext.jsx'
+import FileUpload from '../components/FileUpload.jsx'
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
 
 export default function UploadPage() {
   const { receipt, setReceipt } = useContext(ReceiptContext);
@@ -17,9 +19,9 @@ export default function UploadPage() {
       const formData = new FormData();
       formData.append('file', file);
       // Call backend OCR endpoint
-      const resp = await axios.post('http://localhost:5000/api/upload', formData, {
-        headers: { 'Content-Type': 'multipart/form-data' },
-      });
+      const resp = await axios.post(`${API_BASE_URL}/upload`, formData, {
+        headers: { 'Content-Type': 'multipart/form-data' }
+      })
       // Update state with extracted fields and the uploaded file
       setReceipt({
         ...receipt,


### PR DESCRIPTION
## Summary
- allow frontend to use `VITE_API_BASE_URL` for API calls
- document API base URL env variable in README

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_6887b13e34fc8332bc182b0d1046eb6b