### PR TITLE
Add basic Jest and Pytest tests

### DIFF
--- a/api/tests/test_placeholder.py
+++ b/api/tests/test_placeholder.py
@@ -1,0 +1,3 @@
+
+def test_placeholder():
+    assert True

--- a/backend/__tests__/server.test.js
+++ b/backend/__tests__/server.test.js
@@ -1,0 +1,24 @@
+const request = require('supertest')
+const app = require('../server')
+const fieldMapping = require('../fieldMapping.json')
+
+describe('server routes', () => {
+  it('returns field mapping', async () => {
+    const res = await request(app).get('/api/fields')
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual(fieldMapping)
+  })
+
+  it('rejects upload without file', async () => {
+    const res = await request(app).post('/api/upload')
+    expect(res.status).toBe(400)
+  })
+
+  it('submits stub data', async () => {
+    const res = await request(app)
+      .post('/api/submit')
+      .send({ fields: {}, attachments: [], signature: null })
+    expect(res.status).toBe(200)
+    expect(res.body.success).toBe(true)
+  })
+})

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node'
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "jest"
   },
   "dependencies": {
     "@azure/identity": "^3.4.0",
@@ -15,5 +16,9 @@
 "multer": "2.0.2",
     "tesseract.js": "^4.0.2",
     "isomorphic-fetch": "^3.0.0"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.4"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -71,7 +71,11 @@ app.post('/api/submit', async (req, res) => {
   }
 });
 
-const PORT = process.env.PORT || 5000;
-app.listen(PORT, () => {
-  console.log(`Backend server listening on port ${PORT}`);
-});
+const PORT = process.env.PORT || 5000
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Backend server listening on port ${PORT}`)
+  })
+}
+
+module.exports = app

--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@babel/preset-env', '@babel/preset-react']
+}

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.jsx?$': 'babel-jest'
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "axios": "^1.5.0",
@@ -23,6 +24,13 @@
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.1",
-    "vite": "^5.0.11"
+    "vite": "^5.0.11",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/user-event": "^14.4.3",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0",
+    "@babel/preset-env": "^7.24.0",
+    "@babel/preset-react": "^7.22.15"
   }
 }

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -1,0 +1,13 @@
+import "@testing-library/jest-dom"
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import App from '../App.jsx'
+
+test('shows upload page by default', () => {
+  render(
+    <MemoryRouter initialEntries={['/']}>
+      <App />
+    </MemoryRouter>
+  )
+  expect(screen.getByText(/upload receipt/i)).toBeInTheDocument()
+})

--- a/frontend/src/__tests__/FileUpload.test.jsx
+++ b/frontend/src/__tests__/FileUpload.test.jsx
@@ -1,0 +1,14 @@
+import "@testing-library/jest-dom"
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import FileUpload from '../components/FileUpload.jsx'
+
+test('calls onFileSelected when a file is chosen', async () => {
+  const user = userEvent.setup()
+  const handle = jest.fn()
+  const { container } = render(<FileUpload onFileSelected={handle} />)
+  const input = container.querySelector('input[type="file"]')
+  const file = new File(['hello'], 'test.png', { type: 'image/png' })
+  await user.upload(input, file)
+  expect(handle).toHaveBeenCalledWith(file)
+})


### PR DESCRIPTION
## Summary
- add Jest config and tests for server routes
- export Express app for testing
- add Jest config for React app and tests for components
- add placeholder pytest test
- install new test scripts in package.json files

## Testing
- `npm test -- --watchAll=false` *(fails: jest not found)*
- `npm test -- --watchAll=false` *(fails: jest not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6887b2b2866083328881854c8db37454