### PR TITLE
Fix server export for tests

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -96,7 +96,11 @@ app.post('/api/submit', async (req, res) => {
 
 
 
-const PORT = process.env.PORT || 5000;
-app.listen(PORT, () => {
-  console.log(`Backend server listening on port ${PORT}`);
-});
+module.exports = app
+
+const PORT = process.env.PORT || 5000
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Backend server listening on port ${PORT}`)
+  })
+}


### PR DESCRIPTION
## Summary
- export `app` from `backend/server.js`
- guard `app.listen` so the server only starts when called directly

## Testing
- `npm test -- --watchAll=false` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_688b79b0510c8332ac4a75b162f7189d