### PR TITLE
fix: refine total regex in receipt parser

### DIFF
--- a/backend/parseReceipt.js
+++ b/backend/parseReceipt.js
@@ -65,7 +65,7 @@ function parseReceiptData(tesseractData, mapping) {
     if ('taxTotal' in result) result.taxTotal = val
   }
 
-  const totalMatch = text.match(/(?:grand\s*)?total[^0-9]{0,10}([\d.,]+)/i)
+  const totalMatch = text.match(/\b(?:grand\s*)?total\b[^0-9]{0,10}([\d.,]+)/i)
   if (totalMatch) {
     const val = clean(totalMatch[1])
     result['purchases[0].total'] = val


### PR DESCRIPTION
## Summary
- prevent 'total' regex from matching 'subtotal'

## Testing
- `npm test -- --watchAll=false` *(fails: jest not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_688bfd8365d88332bde21a8ca1ee33a3