### PR TITLE
feat: add msal user context

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,9 @@
     "react-router-dom": "^6.14.1",
     "react-signature-canvas": "^1.0.6",
     "tesseract.js": "^4.0.2",
-    "zustand": "^4.3.8"
+    "zustand": "^4.3.8",
+    "@azure/msal-browser": "^3.0.0",
+    "@azure/msal-react": "^2.0.0"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.7",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,23 +1,28 @@
-import React from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
-import UploadPage from './pages/UploadPage.jsx';
-import ReviewPage from './pages/ReviewPage.jsx';
-import SignaturePage from './pages/SignaturePage.jsx';
-import SubmitPage from './pages/SubmitPage.jsx';
-import { ReceiptProvider } from './context/ReceiptContext.jsx';
+import React from 'react'
+import { Routes, Route, Navigate } from 'react-router-dom'
+import UploadPage from './pages/UploadPage.jsx'
+import ReviewPage from './pages/ReviewPage.jsx'
+import SignaturePage from './pages/SignaturePage.jsx'
+import SubmitPage from './pages/SubmitPage.jsx'
+import { ReceiptProvider } from './context/ReceiptContext.jsx'
+import { UserProvider } from './context/UserContext.jsx'
+import UserHeader from './components/UserHeader.jsx'
 
 export default function App() {
   return (
-    <ReceiptProvider>
-      <div className="min-h-screen bg-gray-50">
-        <Routes>
-          <Route path="/" element={<Navigate to="/upload" replace />} />
-          <Route path="/upload" element={<UploadPage />} />
-          <Route path="/review" element={<ReviewPage />} />
-          <Route path="/signature" element={<SignaturePage />} />
-          <Route path="/submit" element={<SubmitPage />} />
-        </Routes>
-      </div>
-    </ReceiptProvider>
-  );
+    <UserProvider>
+      <ReceiptProvider>
+        <div className="min-h-screen bg-gray-50">
+          <UserHeader />
+          <Routes>
+            <Route path="/" element={<Navigate to="/upload" replace />} />
+            <Route path="/upload" element={<UploadPage />} />
+            <Route path="/review" element={<ReviewPage />} />
+            <Route path="/signature" element={<SignaturePage />} />
+            <Route path="/submit" element={<SubmitPage />} />
+          </Routes>
+        </div>
+      </ReceiptProvider>
+    </UserProvider>
+  )
 }

--- a/frontend/src/components/UserHeader.jsx
+++ b/frontend/src/components/UserHeader.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { UserContext } from '../context/UserContext.jsx'
+
+export default function UserHeader() {
+  const { displayName } = React.useContext(UserContext)
+  if (!displayName) return null
+  return (
+    <div className='p-4 bg-gray-800 text-white text-right'>
+      {displayName}
+    </div>
+  )
+}

--- a/frontend/src/context/UserContext.jsx
+++ b/frontend/src/context/UserContext.jsx
@@ -1,0 +1,43 @@
+import React, { createContext, useEffect, useState } from 'react'
+
+export const UserContext = createContext({ displayName: null })
+
+export function UserProvider({ children }) {
+  const [displayName, setDisplayName] = useState(null)
+
+  useEffect(() => {
+    let active = true
+    async function load() {
+      try {
+        const { PublicClientApplication } = await import('@azure/msal-browser')
+        const pca = new PublicClientApplication({
+          auth: {
+            clientId: import.meta.env.VITE_AZURE_CLIENT_ID,
+            authority: `https://login.microsoftonline.com/${import.meta.env.VITE_AZURE_TENANT_ID}`
+          }
+        })
+        await pca.initialize()
+        const account = await pca
+          .ssoSilent({ scopes: ['User.Read'] })
+          .then(r => r.account)
+        const token = await pca.acquireTokenSilent({
+          scopes: ['User.Read'],
+          account
+        })
+        if (active) setDisplayName(token.account?.name || null)
+      } catch (err) {
+        console.error(err)
+      }
+    }
+    load()
+    return () => {
+      active = false
+    }
+  }, [])
+
+  return (
+    <UserContext.Provider value={{ displayName }}>
+      {children}
+    </UserContext.Provider>
+  )
+}


### PR DESCRIPTION
## Summary
- add msal browser/react dependencies
- initialize PublicClientApplication to load user display name
- display user name in header across app

## Testing
- `npm test -- --watchAll=false` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_b_6891334443f8833298b27517aa063a22