### PR TITLE
feat: allow manual user selection

### DIFF
--- a/backend/__tests__/server.test.js
+++ b/backend/__tests__/server.test.js
@@ -21,4 +21,10 @@ describe('server routes', () => {
     expect(res.status).toBe(200)
     expect(res.body.success).toBe(true)
   })
+
+  it('lists users', async () => {
+    const res = await request(app).get('/api/users')
+    expect(res.status).toBe(200)
+    expect(Array.isArray(res.body)).toBe(true)
+  })
 })

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,7 +4,7 @@ const cors = require('cors');
 const multer = require('multer');
 const Tesseract = require('tesseract.js');
 const { parseReceiptData } = require('./parseReceipt');
-const { createPurchaseRequisition } = require('./sharepointClient');
+const { createPurchaseRequisition, listActiveUsers } = require('./sharepointClient')
 const fieldMapping = require('./fieldMapping.json');
 
 // Initialize Express
@@ -93,6 +93,21 @@ app.post('/api/submit', async (req, res) => {
     res.status(500).json({ success: false, error: err.message });
   }
 });
+
+/**
+ * GET /api/users
+ *
+ * Returns the array of active Azure AD users for manual selection in the UI.
+ */
+app.get('/api/users', async (req, res) => {
+  try {
+    const users = await listActiveUsers()
+    res.json(users)
+  } catch (err) {
+    console.error(err)
+    res.status(500).json({ error: err.message })
+  }
+})
 
 
 

--- a/backend/sharepointClient.js
+++ b/backend/sharepointClient.js
@@ -33,6 +33,27 @@ function getGraphClient() {
 }
 
 /**
+ * List active Azure AD users. When Graph credentials are not configured this
+ * function returns a stub array to allow manual selection during development.
+ */
+async function listActiveUsers() {
+  const graph = getGraphClient()
+  if (!graph) {
+    console.log('SharePoint client not configured. Returning stub users.')
+    return [{ id: 'stub', displayName: 'Test User' }]
+  }
+  try {
+    const res = await graph
+      .api('/users?$select=id,displayName&$filter=accountEnabled eq true')
+      .get()
+    return res.value || []
+  } catch (err) {
+    console.error('Error fetching users:', err)
+    throw err
+  }
+}
+
+/**
  * Create a new item in the SharePoint list using the Graph API.  The
  * `fields` object is keyed by stateKey; this function must translate it
  * into SharePoint internal names (see fieldMapping.json).  Attachments and
@@ -89,4 +110,4 @@ async function createPurchaseRequisition(fields, attachments, signature) {
   }
 }
 
-module.exports = { createPurchaseRequisition };
+module.exports = { createPurchaseRequisition, listActiveUsers }

--- a/frontend/src/components/UserHeader.jsx
+++ b/frontend/src/components/UserHeader.jsx
@@ -2,11 +2,41 @@ import React from 'react'
 import { UserContext } from '../context/UserContext.jsx'
 
 export default function UserHeader() {
-  const { displayName } = React.useContext(UserContext)
-  if (!displayName) return null
+  const { user, setUser } = React.useContext(UserContext)
+  const [users, setUsers] = React.useState([])
+
+  React.useEffect(() => {
+    if (!user) {
+      fetch('/api/users')
+        .then(r => r.json())
+        .then(data => setUsers(data))
+        .catch(err => console.error(err))
+    }
+  }, [user])
+
+  if (!user)
+    return (
+      <div className='p-4 bg-gray-800 text-white text-right'>
+        <select
+          className='text-black'
+          onChange={e => {
+            const u = users.find(x => x.id === e.target.value)
+            setUser(u || null)
+          }}
+        >
+          <option value=''>Select user</option>
+          {users.map(u => (
+            <option key={u.id} value={u.id}>
+              {u.displayName}
+            </option>
+          ))}
+        </select>
+      </div>
+    )
+
   return (
     <div className='p-4 bg-gray-800 text-white text-right'>
-      {displayName}
+      {user.displayName}
     </div>
   )
 }

--- a/frontend/src/context/UserContext.jsx
+++ b/frontend/src/context/UserContext.jsx
@@ -1,9 +1,9 @@
 import React, { createContext, useEffect, useState } from 'react'
 
-export const UserContext = createContext({ displayName: null })
+export const UserContext = createContext({ user: null, setUser: () => {} })
 
 export function UserProvider({ children }) {
-  const [displayName, setDisplayName] = useState(null)
+  const [user, setUser] = useState(null)
 
   useEffect(() => {
     let active = true
@@ -24,7 +24,11 @@ export function UserProvider({ children }) {
           scopes: ['User.Read'],
           account
         })
-        if (active) setDisplayName(token.account?.name || null)
+        if (active)
+          setUser({
+            id: account?.homeAccountId || null,
+            displayName: token.account?.name || null
+          })
       } catch (err) {
         console.error(err)
       }
@@ -35,9 +39,5 @@ export function UserProvider({ children }) {
     }
   }, [])
 
-  return (
-    <UserContext.Provider value={{ displayName }}>
-      {children}
-    </UserContext.Provider>
-  )
+  return <UserContext.Provider value={{ user, setUser }}>{children}</UserContext.Provider>
 }


### PR DESCRIPTION
## Summary
- query Microsoft Graph for active users
- expose backend API for user list
- allow manual user selection on the frontend

## Testing
- `npm test` (backend)
- `npm test -- --watchAll=false` (frontend) *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_b_6891349e0d4c8332bf69d33f351bb3fa