### PR TITLE
feat: add client-side image quality checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ This repo only contains source code; dependencies are not vendored.  To get up a
 
    This will start Vite on port 5173 (or the next available port) and open the app in your default browser.
 
+## Image quality requirements
+
+Uploaded images are evaluated for common problems before OCR:
+
+- **Receipt edges not detected** – ensure the full receipt is visible and clearly framed.
+- **Image is blurry** – retake the photo with better focus.
+- **Low OCR confidence** – improve lighting or use a higher resolution image.
+
+If any issues are found you will be prompted to retake the photo.
+
+
 ## Configuration
 
 ### Field mapping

--- a/frontend/src/__tests__/FileUpload.test.jsx
+++ b/frontend/src/__tests__/FileUpload.test.jsx
@@ -1,9 +1,15 @@
-import "@testing-library/jest-dom"
-import { render } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import FileUpload from '../components/FileUpload.jsx'
+import { checkImageQuality } from '../utils/imageQuality.js'
 
-test('calls onFileSelected when a file is chosen', async () => {
+jest.mock('../utils/imageQuality.js', () => ({
+  checkImageQuality: jest.fn()
+}))
+
+test('calls onFileSelected when a file passes quality check', async () => {
+  checkImageQuality.mockResolvedValue({ ok: true, issues: [] })
   const user = userEvent.setup()
   const handle = jest.fn()
   const { container } = render(<FileUpload onFileSelected={handle} />)
@@ -13,14 +19,14 @@ test('calls onFileSelected when a file is chosen', async () => {
   expect(handle).toHaveBeenCalledWith(file)
 })
 
-test('calls onFileSelected when a photo is taken', async () => {
+test('shows retake message when quality check fails', async () => {
+  checkImageQuality.mockResolvedValue({ ok: false, issues: ['Image is blurry'] })
   const user = userEvent.setup()
   const handle = jest.fn()
-  const { container, getByText } = render(<FileUpload onFileSelected={handle} />)
-  const button = getByText(/take photo/i)
-  const cameraInput = container.querySelector('input[capture="environment"]')
-  const file = new File(['camera'], 'camera.png', { type: 'image/png' })
-  await user.click(button)
-  await user.upload(cameraInput, file)
-  expect(handle).toHaveBeenCalledWith(file)
+  const { container } = render(<FileUpload onFileSelected={handle} />)
+  const input = container.querySelector('input[accept="image/*,application/pdf"]')
+  const file = new File(['bad'], 'bad.png', { type: 'image/png' })
+  await user.upload(input, file)
+  expect(handle).not.toHaveBeenCalled()
+  expect(await screen.findByText(/retake/i)).toBeInTheDocument()
 })

--- a/frontend/src/components/FileUpload.jsx
+++ b/frontend/src/components/FileUpload.jsx
@@ -1,16 +1,30 @@
-import React, { useRef } from 'react'
+import React, { useRef, useState } from 'react'
+import { checkImageQuality } from '../utils/imageQuality.js'
 
 /**
  * A basic file upload component.  When the user selects a file, the
  * `onFileSelected` callback is invoked with the first file in the input.
  */
-export default function FileUpload({ onFileSelected }) {
+export default function FileUpload({ onFileSelected, onQualityIssues }) {
   const cameraInputRef = useRef(null)
+  const [retakeMessage, setRetakeMessage] = useState(false)
 
-  const handleChange = e => {
+  const processFile = async file => {
+    const result = await checkImageQuality(file)
+    if (result.ok) {
+      onQualityIssues?.([])
+      onFileSelected(file)
+    } else {
+      onQualityIssues?.(result.issues)
+      setRetakeMessage(true)
+      setTimeout(() => setRetakeMessage(false), 2000)
+    }
+  }
+
+  const handleChange = async e => {
     const file = e.target.files[0]
     if (file) {
-      onFileSelected(file)
+      await processFile(file)
     }
   }
 
@@ -18,10 +32,10 @@ export default function FileUpload({ onFileSelected }) {
     cameraInputRef.current?.click()
   }
 
-  const handleCameraChange = e => {
+  const handleCameraChange = async e => {
     const file = e.target.files[0]
     if (file) {
-      onFileSelected(file)
+      await processFile(file)
     }
   }
 
@@ -48,8 +62,8 @@ export default function FileUpload({ onFileSelected }) {
       >
         Take Photo
       </button>
+      {retakeMessage && <p className="mt-2 text-red-600">Please retake the photo</p>}
       <p className="mt-2 text-gray-500">Choose an image or PDF of your receipt.</p>
     </div>
   )
 }
-

--- a/frontend/src/pages/UploadPage.jsx
+++ b/frontend/src/pages/UploadPage.jsx
@@ -7,17 +7,19 @@ import FileUpload from '../components/FileUpload.jsx'
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
 
 export default function UploadPage() {
-  const { receipt, setReceipt } = useContext(ReceiptContext);
-  const navigate = useNavigate();
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const { receipt, setReceipt } = useContext(ReceiptContext)
+  const navigate = useNavigate()
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [issues, setIssues] = useState([])
 
-  const handleFileUpload = async (file) => {
-    setError(null);
-    setLoading(true);
+  const handleFileUpload = async file => {
+    setError(null)
+    setIssues([])
+    setLoading(true)
     try {
-      const formData = new FormData();
-      formData.append('file', file);
+      const formData = new FormData()
+      formData.append('file', file)
       // Call backend OCR endpoint
       const resp = await axios.post(`${API_BASE_URL}/upload`, formData, {
         headers: { 'Content-Type': 'multipart/form-data' }
@@ -26,23 +28,32 @@ export default function UploadPage() {
       setReceipt({
         ...receipt,
         fields: resp.data.data || {},
-        attachments: [file],
-      });
-      navigate('/review');
+        attachments: [file]
+      })
+      navigate('/review')
     } catch (err) {
-      console.error(err);
-      setError(err.response?.data?.error || err.message);
+      console.error(err)
+      setError(err.response?.data?.error || err.message)
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  };
+  }
 
   return (
     <div className="max-w-4xl mx-auto py-8">
       <h1 className="text-2xl font-bold mb-4">Upload Receipt</h1>
-      <FileUpload onFileSelected={handleFileUpload} />
+      {issues.length > 0 && (
+        <div className="mb-4">
+          {issues.map((msg, idx) => (
+            <p key={idx} className="text-orange-600">
+              {msg}
+            </p>
+          ))}
+        </div>
+      )}
+      <FileUpload onFileSelected={handleFileUpload} onQualityIssues={setIssues} />
       {loading && <p className="mt-2 text-blue-600">Extracting data…</p>}
       {error && <p className="mt-2 text-red-600">{error}</p>}
     </div>
-  );
+  )
 }

--- a/frontend/src/utils/imageQuality.js
+++ b/frontend/src/utils/imageQuality.js
@@ -1,0 +1,72 @@
+const DEFAULT_THRESHOLDS = {
+  blur: 100,
+  ocr: 60
+}
+
+export async function checkImageQuality(file, thresholds = DEFAULT_THRESHOLDS) {
+  const { default: cv } = await import('opencv.js')
+  const { default: Tesseract } = await import('tesseract.js')
+
+  const issues = []
+
+  const img = await createImageBitmap(file)
+  const canvas = document.createElement('canvas')
+  canvas.width = img.width
+  canvas.height = img.height
+  const ctx = canvas.getContext('2d')
+  ctx.drawImage(img, 0, 0)
+
+  const src = cv.imread(canvas)
+  const gray = new cv.Mat()
+  cv.cvtColor(src, gray, cv.COLOR_RGBA2GRAY, 0)
+
+  const edges = new cv.Mat()
+  cv.Canny(gray, edges, 50, 150)
+  const contours = new cv.MatVector()
+  const hierarchy = new cv.Mat()
+  cv.findContours(edges, contours, hierarchy, cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE)
+  let hasRect = false
+  for (let i = 0; i < contours.size(); i++) {
+    const cnt = contours.get(i)
+    const peri = cv.arcLength(cnt, true)
+    const approx = new cv.Mat()
+    cv.approxPolyDP(cnt, approx, 0.02 * peri, true)
+    if (approx.rows === 4) {
+      const area = cv.contourArea(cnt)
+      if (area > 0.3 * src.rows * src.cols) {
+        hasRect = true
+      }
+    }
+    cnt.delete()
+    approx.delete()
+  }
+  if (!hasRect) {
+    issues.push('Receipt edges not detected')
+  }
+
+  const lap = new cv.Mat()
+  cv.Laplacian(gray, lap, cv.CV_64F)
+  const mean = new cv.Mat()
+  const std = new cv.Mat()
+  cv.meanStdDev(lap, mean, std)
+  const variance = Math.pow(std.doubleAt(0, 0), 2)
+  if (variance < thresholds.blur) {
+    issues.push('Image is blurry')
+  }
+
+  src.delete()
+  gray.delete()
+  edges.delete()
+  contours.delete()
+  hierarchy.delete()
+  lap.delete()
+  mean.delete()
+  std.delete()
+
+  const { data } = await Tesseract.recognize(file)
+  if (data.confidence < thresholds.ocr) {
+    issues.push('Low OCR confidence')
+  }
+
+  return { ok: issues.length === 0, issues }
+}


### PR DESCRIPTION
## Summary
- evaluate uploaded images for receipt edges, blur, and OCR confidence before processing
- block upload and prompt retake when checks fail, surfacing issues to users
- document image quality requirements and supported guidance messages

## Testing
- `npm test -- --watchAll=false` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install --save-dev jest-environment-jsdom` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest-environment-jsdom)*

------
https://chatgpt.com/codex/tasks/task_b_6891422296208332aa8d7227feb16dfa