### PR TITLE
feat: load OpenCV script in frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Receipt Extractor App" />
     <title>Receipt Extractor</title>
+    <script async src="https://docs.opencv.org/4.9.0/opencv.js" onload="onOpenCvReady()" type="text/javascript"></script>
+    <script type="text/javascript">
+      function onOpenCvReady () {
+        window.cv = cv
+      }
+    </script>
   </head>
   <body class="bg-gray-50">
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- load OpenCV.js and expose `cv` globally in the frontend

## Testing
- `npm test -- --watchAll=false` *(fails: jest-environment-jsdom cannot be found; npm registry access forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68927081bf8c8332b24a4b405cd6f924