### PR TITLE
feat: add image quality checks with OCR

### DIFF
--- a/frontend/src/__tests__/FileUpload.test.jsx
+++ b/frontend/src/__tests__/FileUpload.test.jsx
@@ -2,18 +2,40 @@ import "@testing-library/jest-dom"
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import FileUpload from '../components/FileUpload.jsx'
+import { checkImageQuality } from '../utils/imageQuality'
+import { waitFor } from '@testing-library/react'
 
-test('calls onFileSelected when a file is chosen', async () => {
+jest.mock('../utils/imageQuality', () => ({
+  checkImageQuality: jest.fn()
+}))
+
+beforeEach(() => {
+  global.URL.createObjectURL = jest.fn(() => 'blob:mock')
+  global.Image = class {
+    constructor () {
+      setTimeout(() => {
+        this.onload && this.onload()
+      }, 0)
+    }
+    set src (_) {}
+  }
+})
+
+test('calls onFileSelected with quality data when a file is chosen', async () => {
+  checkImageQuality.mockResolvedValue({ blurVariance: 200, hasFourEdges: true, ocrConfidence: 90 })
   const user = userEvent.setup()
   const handle = jest.fn()
   const { container } = render(<FileUpload onFileSelected={handle} />)
   const input = container.querySelector('input[accept="image/*,application/pdf"]')
   const file = new File(['hello'], 'test.png', { type: 'image/png' })
   await user.upload(input, file)
-  expect(handle).toHaveBeenCalledWith(file)
+  await waitFor(() =>
+    expect(handle).toHaveBeenCalledWith(file, { blurVariance: 200, hasFourEdges: true, ocrConfidence: 90 })
+  )
 })
 
-test('calls onFileSelected when a photo is taken', async () => {
+test('calls onFileSelected with quality data when a photo is taken', async () => {
+  checkImageQuality.mockResolvedValue({ blurVariance: 200, hasFourEdges: true, ocrConfidence: 90 })
   const user = userEvent.setup()
   const handle = jest.fn()
   const { container, getByText } = render(<FileUpload onFileSelected={handle} />)
@@ -22,5 +44,7 @@ test('calls onFileSelected when a photo is taken', async () => {
   const file = new File(['camera'], 'camera.png', { type: 'image/png' })
   await user.click(button)
   await user.upload(cameraInput, file)
-  expect(handle).toHaveBeenCalledWith(file)
+  await waitFor(() =>
+    expect(handle).toHaveBeenCalledWith(file, { blurVariance: 200, hasFourEdges: true, ocrConfidence: 90 })
+  )
 })

--- a/frontend/src/__tests__/uploadQuality.test.jsx
+++ b/frontend/src/__tests__/uploadQuality.test.jsx
@@ -1,0 +1,67 @@
+import '@testing-library/jest-dom'
+import { render, fireEvent, screen } from '@testing-library/react'
+import UploadPage from '../pages/UploadPage.jsx'
+import { ReceiptContext } from '../context/ReceiptContext.jsx'
+import axios from 'axios'
+import { checkImageQuality } from '../utils/imageQuality'
+import { MemoryRouter } from 'react-router-dom'
+
+jest.mock('axios')
+jest.mock('../utils/imageQuality', () => ({
+  checkImageQuality: jest.fn()
+}))
+
+const renderPage = () =>
+  render(
+    <ReceiptContext.Provider value={{ receipt: {}, setReceipt: jest.fn() }}>
+      <MemoryRouter>
+        <UploadPage />
+      </MemoryRouter>
+    </ReceiptContext.Provider>
+  )
+
+beforeEach(() => {
+  axios.post.mockReset()
+  global.URL.createObjectURL = jest.fn(() => 'blob:mock')
+  global.Image = class {
+    constructor () {
+      setTimeout(() => {
+        this.onload && this.onload()
+      }, 0)
+    }
+    set src (_) {}
+  }
+})
+
+test('rejects blurry image', async () => {
+  checkImageQuality.mockResolvedValue({ blurVariance: 10, hasFourEdges: true, ocrConfidence: 90 })
+  const { container } = renderPage()
+  const file = new File(['blur'], 'blur.jpg', { type: 'image/jpeg' })
+  fireEvent.change(container.querySelector('input[accept="image/*,application/pdf"]'), {
+    target: { files: [file] }
+  })
+  await screen.findByText(/blurry/i)
+  expect(axios.post).not.toHaveBeenCalled()
+})
+
+test('rejects image missing edges', async () => {
+  checkImageQuality.mockResolvedValue({ blurVariance: 200, hasFourEdges: false, ocrConfidence: 90 })
+  const { container } = renderPage()
+  const file = new File(['edge'], 'edge.jpg', { type: 'image/jpeg' })
+  fireEvent.change(container.querySelector('input[accept="image/*,application/pdf"]'), {
+    target: { files: [file] }
+  })
+  await screen.findByText(/receipt edges not detected/i)
+  expect(axios.post).not.toHaveBeenCalled()
+})
+
+test('rejects image with low OCR confidence', async () => {
+  checkImageQuality.mockResolvedValue({ blurVariance: 200, hasFourEdges: true, ocrConfidence: 20 })
+  const { container } = renderPage()
+  const file = new File(['ocr'], 'ocr.jpg', { type: 'image/jpeg' })
+  fireEvent.change(container.querySelector('input[accept="image/*,application/pdf"]'), {
+    target: { files: [file] }
+  })
+  await screen.findByText(/text is not clear/i)
+  expect(axios.post).not.toHaveBeenCalled()
+})

--- a/frontend/src/components/FileUpload.jsx
+++ b/frontend/src/components/FileUpload.jsx
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react'
+import { checkImageQuality } from '../utils/imageQuality'
 
 /**
  * A basic file upload component.  When the user selects a file, the
@@ -7,10 +8,20 @@ import React, { useRef } from 'react'
 export default function FileUpload({ onFileSelected }) {
   const cameraInputRef = useRef(null)
 
+  const processFile = file => {
+    const img = new Image()
+    img.onload = async () => {
+      const quality = await checkImageQuality(img)
+      onFileSelected(file, quality)
+      URL.revokeObjectURL(img.src)
+    }
+    img.src = URL.createObjectURL(file)
+  }
+
   const handleChange = e => {
     const file = e.target.files[0]
     if (file) {
-      onFileSelected(file)
+      processFile(file)
     }
   }
 
@@ -21,7 +32,7 @@ export default function FileUpload({ onFileSelected }) {
   const handleCameraChange = e => {
     const file = e.target.files[0]
     if (file) {
-      onFileSelected(file)
+      processFile(file)
     }
   }
 

--- a/frontend/src/pages/UploadPage.jsx
+++ b/frontend/src/pages/UploadPage.jsx
@@ -7,42 +7,74 @@ import FileUpload from '../components/FileUpload.jsx'
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
 
 export default function UploadPage() {
-  const { receipt, setReceipt } = useContext(ReceiptContext);
-  const navigate = useNavigate();
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const { receipt, setReceipt } = useContext(ReceiptContext)
+  const navigate = useNavigate()
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [inputKey, setInputKey] = useState(0)
 
-  const handleFileUpload = async (file) => {
-    setError(null);
-    setLoading(true);
+  const handleFileUpload = async (file, quality) => {
+    setError(null)
+    if (quality?.error) {
+      setError(quality.error)
+      return
+    }
+    if (!quality?.hasFourEdges) {
+      setError('Receipt edges not detected. Ensure entire receipt is visible and retry.')
+      return
+    }
+    if (quality.blurVariance < 100) {
+      setError('Image is too blurry. Please retake.')
+      return
+    }
+    if (quality.ocrConfidence < 60) {
+      setError('Text is not clear enough. Retake in better lighting.')
+      return
+    }
+
+    setLoading(true)
     try {
-      const formData = new FormData();
-      formData.append('file', file);
-      // Call backend OCR endpoint
+      const formData = new FormData()
+      formData.append('file', file)
       const resp = await axios.post(`${API_BASE_URL}/upload`, formData, {
         headers: { 'Content-Type': 'multipart/form-data' }
       })
-      // Update state with extracted fields and the uploaded file
       setReceipt({
         ...receipt,
         fields: resp.data.data || {},
-        attachments: [file],
-      });
-      navigate('/review');
+        attachments: [file]
+      })
+      navigate('/review')
     } catch (err) {
-      console.error(err);
-      setError(err.response?.data?.error || err.message);
+      console.error(err)
+      setError(err.response?.data?.error || err.message)
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  };
+  }
+
+  const handleRetake = () => {
+    setError(null)
+    setInputKey(k => k + 1)
+  }
 
   return (
     <div className="max-w-4xl mx-auto py-8">
       <h1 className="text-2xl font-bold mb-4">Upload Receipt</h1>
-      <FileUpload onFileSelected={handleFileUpload} />
+      <FileUpload key={inputKey} onFileSelected={handleFileUpload} />
       {loading && <p className="mt-2 text-blue-600">Extracting data…</p>}
-      {error && <p className="mt-2 text-red-600">{error}</p>}
+      {error && (
+        <div className="mt-2">
+          <p className="text-red-600">{error}</p>
+          <button
+            type="button"
+            onClick={handleRetake}
+            className="mt-2 px-4 py-2 bg-gray-200 rounded"
+          >
+            Retake
+          </button>
+        </div>
+      )}
     </div>
-  );
+  )
 }

--- a/frontend/src/utils/imageQuality.js
+++ b/frontend/src/utils/imageQuality.js
@@ -10,18 +10,54 @@ export const checkImageQuality = async imageElement => {
     const mat = cv.imread(imageElement)
     const gray = new cv.Mat()
     cv.cvtColor(mat, gray, cv.COLOR_RGBA2GRAY)
+
     const laplacian = new cv.Mat()
     cv.Laplacian(gray, laplacian, cv.CV_64F)
     const mean = new cv.Mat()
     const stddev = new cv.Mat()
     cv.meanStdDev(laplacian, mean, stddev)
     const variance = stddev.data64F[0] ** 2
-    const isBlurry = variance < 100
-    mat.delete(); gray.delete(); laplacian.delete(); mean.delete(); stddev.delete()
+
+    cv.GaussianBlur(gray, gray, new cv.Size(5, 5), 0)
+    const edges = new cv.Mat()
+    cv.Canny(gray, edges, 75, 200)
+    const contours = new cv.MatVector()
+    const hierarchy = new cv.Mat()
+    cv.findContours(edges, contours, hierarchy, cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE)
+    let hasFourEdges = false
+    for (let i = 0; i < contours.size(); i++) {
+      const cnt = contours.get(i)
+      const peri = cv.arcLength(cnt, true)
+      const approx = new cv.Mat()
+      cv.approxPolyDP(cnt, approx, 0.02 * peri, true)
+      if (approx.rows === 4) {
+        hasFourEdges = true
+        approx.delete()
+        cnt.delete()
+        break
+      }
+      approx.delete()
+      cnt.delete()
+    }
+    edges.delete()
+    contours.delete()
+    hierarchy.delete()
+
+    const { default: Tesseract } = await import('tesseract.js')
+    const {
+      data: { confidence }
+    } = await Tesseract.recognize(imageElement, 'eng')
+
+    mat.delete()
+    gray.delete()
+    laplacian.delete()
+    mean.delete()
+    stddev.delete()
+
     return {
-      isBlurry,
-      variance,
-      quality: variance > 500 ? 'high' : variance > 100 ? 'medium' : 'low'
+      blurVariance: variance,
+      hasFourEdges,
+      ocrConfidence: confidence
     }
   } catch (error) {
     console.error('Error checking image quality:', error)


### PR DESCRIPTION
## Summary
- expand image quality utility with edge detection and OCR confidence
- block uploads on poor quality and allow retakes
- test quality failures for blur, edges, and OCR confidence

## Testing
- `npm test -- --watchAll=false` *(fails: Test environment jest-environment-jsdom cannot be found; install failed with 403)*

------
https://chatgpt.com/codex/tasks/task_b_689277904bdc833291a80216927f3204