### PR TITLE
feat: support multi-file uploads

### DIFF
--- a/backend/__tests__/upload.test.js
+++ b/backend/__tests__/upload.test.js
@@ -1,0 +1,19 @@
+const request = require('supertest')
+
+jest.mock('tesseract.js', () => ({
+  recognize: jest.fn(() => Promise.resolve({ data: { text: '' } })),
+}))
+
+const app = require('../server')
+
+describe('upload multiple files', () => {
+  it('returns results for each file', async () => {
+    const res = await request(app)
+      .post('/api/upload')
+      .attach('files', Buffer.from('one'), 'one.png')
+      .attach('files', Buffer.from('two'), 'two.png')
+    expect(res.status).toBe(200)
+    expect(Array.isArray(res.body)).toBe(true)
+    expect(res.body).toHaveLength(2)
+  })
+})

--- a/frontend/src/__tests__/FileUpload.test.jsx
+++ b/frontend/src/__tests__/FileUpload.test.jsx
@@ -1,15 +1,21 @@
-import "@testing-library/jest-dom"
-import { render } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import FileUpload from '../components/FileUpload.jsx'
 import { checkImageQuality } from '../utils/imageQuality'
-import { waitFor } from '@testing-library/react'
 
 jest.mock('../utils/imageQuality', () => ({
-  checkImageQuality: jest.fn()
+  checkImageQuality: jest.fn(),
 }))
 
 beforeEach(() => {
+  checkImageQuality.mockImplementation(() =>
+    Promise.resolve({
+      blurVariance: 200,
+      hasFourEdges: true,
+      ocrConfidence: 90,
+    })
+  )
   global.URL.createObjectURL = jest.fn(() => 'blob:mock')
   global.Image = class {
     constructor () {
@@ -21,8 +27,7 @@ beforeEach(() => {
   }
 })
 
-test('calls onFileSelected with quality data when a file is chosen', async () => {
-  checkImageQuality.mockResolvedValue({ blurVariance: 200, hasFourEdges: true, ocrConfidence: 90 })
+test('calls onFileSelected with array when a file is chosen', async () => {
   const user = userEvent.setup()
   const handle = jest.fn()
   const { container } = render(<FileUpload onFileSelected={handle} />)
@@ -30,12 +35,16 @@ test('calls onFileSelected with quality data when a file is chosen', async () =>
   const file = new File(['hello'], 'test.png', { type: 'image/png' })
   await user.upload(input, file)
   await waitFor(() =>
-    expect(handle).toHaveBeenCalledWith(file, { blurVariance: 200, hasFourEdges: true, ocrConfidence: 90 })
+    expect(handle).toHaveBeenCalledWith([
+      {
+        file,
+        quality: { blurVariance: 200, hasFourEdges: true, ocrConfidence: 90 },
+      },
+    ])
   )
 })
 
-test('calls onFileSelected with quality data when a photo is taken', async () => {
-  checkImageQuality.mockResolvedValue({ blurVariance: 200, hasFourEdges: true, ocrConfidence: 90 })
+test('calls onFileSelected with array when a photo is taken', async () => {
   const user = userEvent.setup()
   const handle = jest.fn()
   const { container, getByText } = render(<FileUpload onFileSelected={handle} />)
@@ -45,6 +54,29 @@ test('calls onFileSelected with quality data when a photo is taken', async () =>
   await user.click(button)
   await user.upload(cameraInput, file)
   await waitFor(() =>
-    expect(handle).toHaveBeenCalledWith(file, { blurVariance: 200, hasFourEdges: true, ocrConfidence: 90 })
+    expect(handle).toHaveBeenCalledWith([
+      {
+        file,
+        quality: { blurVariance: 200, hasFourEdges: true, ocrConfidence: 90 },
+      },
+    ])
   )
+})
+
+test('handles multiple file selection', async () => {
+  const user = userEvent.setup()
+  const handle = jest.fn()
+  const { container } = render(<FileUpload onFileSelected={handle} />)
+  const input = container.querySelector('input[accept="image/*,application/pdf"]')
+  const files = [
+    new File(['one'], 'one.png', { type: 'image/png' }),
+    new File(['two'], 'two.png', { type: 'image/png' }),
+  ]
+  await user.upload(input, files)
+  await waitFor(() => expect(handle).toHaveBeenCalledTimes(1))
+  const result = handle.mock.calls[0][0]
+  expect(Array.isArray(result)).toBe(true)
+  expect(result).toHaveLength(2)
+  expect(result[0].file).toBe(files[0])
+  expect(result[1].file).toBe(files[1])
 })


### PR DESCRIPTION
## Summary
- allow drag-and-drop and multi-select uploads on the frontend
- handle arrays of files during upload and FormData creation
- accept multiple files in backend upload route and parse each
- add tests for multi-file flows

## Testing
- `npm test -- --watchAll=false` (backend)
- `npm test -- --watchAll=false` (frontend) *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_b_689282d2d72483329f6a23ea2fc59f25