### PR TITLE
fix: specify tus-js-client version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
-    "dotenv": "^17.2.1"
+    "dotenv": "^17.2.1",
+    "tus-js-client": "latest"
   }
 }


### PR DESCRIPTION
## Summary
- specify tus-js-client dependency with a valid version string

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/tus-js-client`)


------
https://chatgpt.com/codex/tasks/task_b_68929495a5088332b4befcadde119e2e