### PR TITLE
test: add file upload quality assertions

### DIFF
--- a/frontend/src/__tests__/FileUpload.test.jsx
+++ b/frontend/src/__tests__/FileUpload.test.jsx
@@ -122,7 +122,8 @@ test('shows ready status after quality check', async () => {
   const input = container.querySelector('input[accept="image/*,application/pdf"]')
   const file = new File(['ok'], 'ok.png', { type: 'image/png' })
   await user.upload(input, file)
-  await findByText(/checking/i)
+  const checking = await findByText(/checking/i)
+  await waitFor(() => expect(checking).not.toBeInTheDocument())
   await waitFor(() => expect(container).toHaveTextContent(/ready/i))
 })
 
@@ -133,12 +134,16 @@ test('shows unreadable status with reason', async () => {
     ocrConfidence: 90,
   })
   const user = userEvent.setup()
-  const { container, getByTitle } = render(
+  const { container, findByText, getByTitle } = render(
     <FileUpload onFileSelected={() => {}} />
   )
   const input = container.querySelector('input[accept="image/*,application/pdf"]')
   const file = new File(['bad'], 'bad.png', { type: 'image/png' })
   await user.upload(input, file)
+  const checking = await findByText(/checking/i)
+  await waitFor(() => expect(checking).not.toBeInTheDocument())
   await waitFor(() => expect(container).toHaveTextContent(/unreadable/i))
-  getByTitle(QUALITY_MESSAGES.blur)
+  const icon = getByTitle(QUALITY_MESSAGES.blur)
+  expect(icon).toBeInTheDocument()
+  expect(icon.querySelector('svg')).toBeInTheDocument()
 })

--- a/frontend/src/__tests__/uploadQuality.test.jsx
+++ b/frontend/src/__tests__/uploadQuality.test.jsx
@@ -42,6 +42,7 @@ test('rejects blurry image', async () => {
     target: { files: [file] }
   })
   await screen.findByText(/blurry/i)
+  expect(screen.queryByText(/Attachments Ready for Submit/i)).not.toBeInTheDocument()
   expect(axios.post).not.toHaveBeenCalled()
 })
 
@@ -53,6 +54,7 @@ test('rejects image missing edges', async () => {
     target: { files: [file] }
   })
   await screen.findByText(/receipt edges not detected/i)
+  expect(screen.queryByText(/Attachments Ready for Submit/i)).not.toBeInTheDocument()
   expect(axios.post).not.toHaveBeenCalled()
 })
 
@@ -64,5 +66,21 @@ test('rejects image with low OCR confidence', async () => {
     target: { files: [file] }
   })
   await screen.findByText(QUALITY_MESSAGES.ocr)
+  expect(screen.queryByText(/Attachments Ready for Submit/i)).not.toBeInTheDocument()
   expect(axios.post).not.toHaveBeenCalled()
+})
+
+test('shows attachments ready for submit when quality passes', async () => {
+  checkImageQuality.mockResolvedValue({
+    blurVariance: 200,
+    hasFourEdges: true,
+    ocrConfidence: 90,
+  })
+  const { container } = renderPage()
+  const file = new File(['good'], 'good.jpg', { type: 'image/jpeg' })
+  fireEvent.change(container.querySelector('input[accept="image/*,application/pdf"]'), {
+    target: { files: [file] }
+  })
+  await screen.findByText(/Attachments Ready for Submit/i)
+  expect(screen.getByAltText('ready-0')).toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary
- ensure FileUpload shows status transitions and info icon
- verify UploadPage only lists attachments when quality passes

## Testing
- `cd frontend && npm test -- --watchAll=false` *(fails: jest-environment-jsdom cannot be found)*
- `npm install jest-environment-jsdom@^29.7.0 --save-dev` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6892a00227948332b8e7c75687fba8ec