### PR TITLE
fix: normalize purchase field keys

### DIFF
--- a/backend/parseReceipt.js
+++ b/backend/parseReceipt.js
@@ -19,9 +19,13 @@
  */
 function parseReceiptData(tesseractData, mapping) {
   const result = {}
+  const purchaseIndex = 0
   mapping.forEach((field) => {
-    result[field.stateKey] = ''
+    const key = field.stateKey.replace('[i]', `[${purchaseIndex}]`)
+    result[key] = ''
   })
+
+  const pKey = (name) => `purchases[${purchaseIndex}].${name}`
 
   const text = tesseractData.text || ''
   const lines = text.split(/\r?\n/).map((l) => l.trim()).filter(Boolean)
@@ -37,14 +41,14 @@ function parseReceiptData(tesseractData, mapping) {
       const month = r === datePatterns[0] ? m[1] : m[2]
       const day = r === datePatterns[0] ? m[2] : m[3]
       const normalized = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`
-      result['purchases[0].date'] = normalized
+      result[pKey('date')] = normalized
       break
     }
   }
 
   for (const line of lines) {
     if (!/[0-9]/.test(line) && line.length && line.length < 40) {
-      result['purchases[0].vendor'] = line
+      result[pKey('vendor')] = line
       break
     }
   }
@@ -54,21 +58,21 @@ function parseReceiptData(tesseractData, mapping) {
   const subMatch = text.match(/subtotal[^0-9]{0,10}([\d.,]+)/i)
   if (subMatch) {
     const val = clean(subMatch[1])
-    result['purchases[0].subtotal'] = val
+    result[pKey('subtotal')] = val
     if ('subtotalP' in result) result.subtotalP = val
   }
 
   const taxMatch = text.match(/(?:sales\s*)?tax[^0-9]{0,10}([\d.,]+)/i)
   if (taxMatch) {
     const val = clean(taxMatch[1])
-    result['purchases[0].tax'] = val
+    result[pKey('tax')] = val
     if ('taxTotal' in result) result.taxTotal = val
   }
 
   const totalMatch = text.match(/\b(?:grand\s*)?total\b[^0-9]{0,10}([\d.,]+)/i)
   if (totalMatch) {
     const val = clean(totalMatch[1])
-    result['purchases[0].total'] = val
+    result[pKey('total')] = val
     if ('grandTotal' in result) result.grandTotal = val
     if ('vendorTotal' in result) result.vendorTotal = val
   }

--- a/frontend/src/pages/ReviewPage.jsx
+++ b/frontend/src/pages/ReviewPage.jsx
@@ -9,6 +9,7 @@ export default function ReviewPage() {
   const { receipt, setReceipt } = useContext(ReceiptContext);
   const [mapping, setMapping] = useState([]);
   const navigate = useNavigate();
+  const resolveKey = (key, idx = 0) => key.replace('[i]', `[${idx}]`)
 
   useEffect(() => {
     // Fetch field mapping from backend so the form knows which fields to display.
@@ -41,20 +42,23 @@ export default function ReviewPage() {
     <div className="max-w-4xl mx-auto py-8">
       <h1 className="text-2xl font-bold mb-4">Review Extracted Data</h1>
       <form>
-        {mapping.map((field) => (
-          <div key={field.stateKey} className="mb-4">
-            <label className="block text-sm font-medium text-gray-700">
-              {field.label}
-              {field.required ? ' *' : ''}
-            </label>
-            <input
-              type="text"
-              value={receipt.fields[field.stateKey] || ''}
-              onChange={(e) => handleChange(field.stateKey, e.target.value)}
-              className="mt-1 p-2 block w-full border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 text-sm"
-            />
-          </div>
-        ))}
+        {mapping.map((field) => {
+          const resolvedKey = resolveKey(field.stateKey)
+          return (
+            <div key={field.stateKey} className="mb-4">
+              <label className="block text-sm font-medium text-gray-700">
+                {field.label}
+                {field.required ? ' *' : ''}
+              </label>
+              <input
+                type="text"
+                value={receipt.fields[resolvedKey] || ''}
+                onChange={(e) => handleChange(resolvedKey, e.target.value)}
+                className="mt-1 p-2 block w-full border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 text-sm"
+              />
+            </div>
+          )
+        })}
       </form>
       <button
         type="button"

--- a/frontend/src/pages/UploadPage.jsx
+++ b/frontend/src/pages/UploadPage.jsx
@@ -44,9 +44,14 @@ export default function UploadPage() {
       const resp = await axios.post(`${API_BASE_URL}/upload`, formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
       })
-      const fields = Array.isArray(resp.data)
+      const rawFields = Array.isArray(resp.data)
         ? resp.data.reduce((acc, cur) => ({ ...acc, ...(cur.data || {}) }), {})
         : resp.data.data || {}
+      const normalizeKeys = (obj) =>
+        Object.fromEntries(
+          Object.entries(obj).map(([k, v]) => [k.replace('[i]', '[0]'), v])
+        )
+      const fields = normalizeKeys(rawFields)
       setReceipt({
         ...receipt,
         fields,


### PR DESCRIPTION
## Summary
- normalize purchase key generation in OCR parser
- resolve `purchases[i]` placeholders on upload and review pages

## Testing
- `npm test -- --watchAll=false` (backend)
- `npm test -- --watchAll=false` *(fails: jest-environment-jsdom missing, install 403)*

------
https://chatgpt.com/codex/tasks/task_b_6892a430f49483328e400555eac3f637