### PR TITLE
feat: upload attachment content

### DIFF
--- a/backend/__tests__/sharepointClient.test.js
+++ b/backend/__tests__/sharepointClient.test.js
@@ -1,0 +1,52 @@
+const mockApiCalls = []
+const mockPost = jest.fn()
+const mockPut = jest.fn()
+
+jest.mock('@azure/identity', () => ({
+  ClientSecretCredential: jest.fn().mockImplementation(() => ({
+    getToken: jest.fn(() => Promise.resolve({ token: 'token' })),
+  })),
+}))
+
+jest.mock('@microsoft/microsoft-graph-client', () => ({
+  Client: {
+    initWithMiddleware: jest.fn(() => ({
+      api: (path) => {
+        mockApiCalls.push(path)
+        return { post: mockPost, put: mockPut }
+      },
+    })),
+  },
+}))
+
+describe('createPurchaseRequisition attachments', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    mockApiCalls.length = 0
+    mockPost.mockReset()
+    mockPut.mockReset()
+    process.env.TENANT_ID = 't'
+    process.env.CLIENT_ID = 'c'
+    process.env.CLIENT_SECRET = 's'
+    process.env.SITE_ID = 'site'
+    process.env.LIST_ID = 'list'
+  })
+
+  it('uploads attachment content', async () => {
+    const { createPurchaseRequisition } = require('../sharepointClient')
+    const base64 = Buffer.from('hello').toString('base64')
+    mockPost.mockResolvedValueOnce({ id: 'item1' })
+
+    await createPurchaseRequisition(
+      {},
+      [{ name: 'file.txt', type: 'text/plain', content: base64 }],
+      null
+    )
+
+    expect(mockApiCalls).toContain('/sites/site/lists/list/items')
+    expect(mockApiCalls).toContain(
+      '/sites/site/lists/list/items/item1/attachments/file.txt/$value'
+    )
+    expect(mockPut).toHaveBeenCalledWith(Buffer.from(base64, 'base64'))
+  })
+})

--- a/backend/server.js
+++ b/backend/server.js
@@ -81,22 +81,27 @@ app.post('/api/upload', (req, res) => {
 /**
  * POST /api/submit
  *
- * Accepts a JSON payload containing `fields`, an array of `attachments`, and
- * a `signature` data URL.  It passes the data to the SharePoint client
- * abstraction which performs the Graph API calls.  This implementation
- * currently logs the data and returns a stub response if no Graph
- * credentials are configured.
+ * Accepts a JSON payload containing `fields`, an array of `attachments`
+ * (each with `name`, `type` and base64 `content`), and a `signature` data URL.
+ * It passes the data to the SharePoint client abstraction which performs the
+ * Graph API calls.  This implementation currently logs the data and returns a
+ * stub response if no Graph credentials are configured.
  */
 app.post('/api/submit', async (req, res) => {
   try {
-    const { fields, attachments, signature } = req.body;
-    const response = await createPurchaseRequisition(fields, attachments, signature);
-    res.json({ success: true, response });
+    const { fields, attachments, signature } = req.body
+    const normalized = (attachments || []).map((f) => ({
+      name: f.name,
+      type: f.type,
+      content: f.content,
+    }))
+    const response = await createPurchaseRequisition(fields, normalized, signature)
+    res.json({ success: true, response })
   } catch (err) {
-    console.error(err);
-    res.status(500).json({ success: false, error: err.message });
+    console.error(err)
+    res.status(500).json({ success: false, error: err.message })
   }
-});
+})
 
 /**
  * GET /api/users

--- a/backend/sharepointClient.js
+++ b/backend/sharepointClient.js
@@ -64,6 +64,7 @@ async function listActiveUsers() {
  * @param {Object} fields An object keyed by stateKey containing user
  *   populated values.
  * @param {Array} attachments An array of objects describing uploaded files.
+ *   Each object should include `name`, `type`, and a base64 `content` string.
  * @param {string|null} signature A base64 data URL of the signature image.
  */
 async function createPurchaseRequisition(fields, attachments, signature) {
@@ -92,15 +93,12 @@ async function createPurchaseRequisition(fields, attachments, signature) {
     // Upload attachments if provided
     if (attachments && attachments.length > 0) {
       for (const file of attachments) {
-        // In a real implementation you would read the file content and
-        // upload it as an attachment to the list item
+        const contentBytes = Buffer.from(file.content || '', 'base64')
         await graph
-          .api(`/sites/${siteId}/lists/${listId}/items/${item.id}/attachments`)
-          .post({
-            '@microsoft.graph.downloadUrl': file.contentUrl,
-            'name': file.name,
-            'contentType': file.type,
-          });
+          .api(
+            `/sites/${siteId}/lists/${listId}/items/${item.id}/attachments/${file.name}/$value`
+          )
+          .put(contentBytes)
       }
     }
     return item;

--- a/frontend/src/pages/SubmitPage.jsx
+++ b/frontend/src/pages/SubmitPage.jsx
@@ -11,27 +11,37 @@ export default function SubmitPage() {
   const [success, setSuccess] = useState(false);
 
   const handleSubmit = async () => {
-    setLoading(true);
-    setError(null);
-    setSuccess(false);
+    setLoading(true)
+    setError(null)
+    setSuccess(false)
     try {
+      const attachments = await Promise.all(
+        (receipt.attachments || []).map(
+          (file) =>
+            new Promise((resolve, reject) => {
+              const reader = new FileReader()
+              reader.onload = () => {
+                const base64 = reader.result.split(',')[1]
+                resolve({ name: file.name, type: file.type, content: base64 })
+              }
+              reader.onerror = reject
+              reader.readAsDataURL(file)
+            })
+        )
+      )
       await axios.post(`${API_BASE_URL}/submit`, {
         fields: receipt.fields,
-        attachments: receipt.attachments.map((file) => ({
-          name: file.name,
-          type: file.type,
-          // In a real implementation the file content would be uploaded separately.
-        })),
+        attachments,
         signature: receipt.signature,
-      });
-      setSuccess(true);
+      })
+      setSuccess(true)
     } catch (e) {
-      console.error(e);
-      setError(e.response?.data?.error || e.message);
+      console.error(e)
+      setError(e.response?.data?.error || e.message)
     } finally {
-      setLoading(false);
+      setLoading(false)
     }
-  };
+  }
 
   return (
     <div className="max-w-4xl mx-auto py-8">


### PR DESCRIPTION
## Summary
- send receipt attachments as base64 from submit page
- normalize and forward attachment content on server
- upload attachment bytes to SharePoint in client
- add tests covering attachment handling

## Testing
- `cd backend && npm test -- --watchAll=false --runInBand`
- `cd frontend && npm test -- --watchAll=false` *(fails: jest-environment-jsdom missing)*
- `npm install --save-dev jest-environment-jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6892b51d1e0c83328d52cf25ad30859e