### PR TITLE
feat: support configurable API base URL in UserHeader

### DIFF
--- a/frontend/src/components/UserHeader.jsx
+++ b/frontend/src/components/UserHeader.jsx
@@ -1,13 +1,15 @@
 import React from 'react'
 import { UserContext } from '../context/UserContext.jsx'
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
+
 export default function UserHeader() {
   const { user, setUser } = React.useContext(UserContext)
   const [users, setUsers] = React.useState([])
 
   React.useEffect(() => {
     if (!user) {
-      fetch('/api/users')
+      fetch(`${API_BASE_URL}/users`)
         .then(r => r.json())
         .then(data => setUsers(data))
         .catch(err => console.error(err))


### PR DESCRIPTION
## Summary
- allow configurable API base URL in `UserHeader` via `VITE_API_BASE_URL` env var

## Testing
- `npm test -- --watchAll=false` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_6892b79eb1688332b7a0fd14d710e023