### PR TITLE
fix: free OpenCV resources on error

### DIFF
--- a/frontend/src/utils/imageQuality.js
+++ b/frontend/src/utils/imageQuality.js
@@ -11,54 +11,48 @@ const waitForOpenCV = (timeout = 5000) =>
   })
 
 export const checkImageQuality = async imageElement => {
+  let mat, gray, laplacian, mean, stddev, edges, contours, hierarchy
   try {
     const cv = await waitForOpenCV()
-    const mat = cv.imread(imageElement)
-    const gray = new cv.Mat()
+    mat = cv.imread(imageElement)
+    gray = new cv.Mat()
     cv.cvtColor(mat, gray, cv.COLOR_RGBA2GRAY)
 
-    const laplacian = new cv.Mat()
+    laplacian = new cv.Mat()
     cv.Laplacian(gray, laplacian, cv.CV_64F)
-    const mean = new cv.Mat()
-    const stddev = new cv.Mat()
+    mean = new cv.Mat()
+    stddev = new cv.Mat()
     cv.meanStdDev(laplacian, mean, stddev)
     const variance = stddev.data64F[0] ** 2
 
     cv.GaussianBlur(gray, gray, new cv.Size(5, 5), 0)
-    const edges = new cv.Mat()
+    edges = new cv.Mat()
     cv.Canny(gray, edges, 75, 200)
-    const contours = new cv.MatVector()
-    const hierarchy = new cv.Mat()
+    contours = new cv.MatVector()
+    hierarchy = new cv.Mat()
     cv.findContours(edges, contours, hierarchy, cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE)
     let hasFourEdges = false
     for (let i = 0; i < contours.size(); i++) {
       const cnt = contours.get(i)
-      const peri = cv.arcLength(cnt, true)
-      const approx = new cv.Mat()
-      cv.approxPolyDP(cnt, approx, 0.02 * peri, true)
-      if (approx.rows === 4) {
-        hasFourEdges = true
-        approx.delete()
+      let approx
+      try {
+        const peri = cv.arcLength(cnt, true)
+        approx = new cv.Mat()
+        cv.approxPolyDP(cnt, approx, 0.02 * peri, true)
+        if (approx.rows === 4) {
+          hasFourEdges = true
+          break
+        }
+      } finally {
+        if (approx) approx.delete()
         cnt.delete()
-        break
       }
-      approx.delete()
-      cnt.delete()
     }
-    edges.delete()
-    contours.delete()
-    hierarchy.delete()
 
     const { default: Tesseract } = await import('tesseract.js')
     const {
       data: { confidence }
     } = await Tesseract.recognize(imageElement, 'eng')
-
-    mat.delete()
-    gray.delete()
-    laplacian.delete()
-    mean.delete()
-    stddev.delete()
 
     return {
       blurVariance: variance,
@@ -68,5 +62,14 @@ export const checkImageQuality = async imageElement => {
   } catch (error) {
     console.error('Error checking image quality:', error)
     return { error: error.message || 'Failed to analyze image quality' }
+  } finally {
+    if (mat) mat.delete()
+    if (gray) gray.delete()
+    if (laplacian) laplacian.delete()
+    if (mean) mean.delete()
+    if (stddev) stddev.delete()
+    if (edges) edges.delete()
+    if (contours) contours.delete()
+    if (hierarchy) hierarchy.delete()
   }
 }

--- a/frontend/src/utils/imageQuality.test.js
+++ b/frontend/src/utils/imageQuality.test.js
@@ -1,0 +1,64 @@
+import { checkImageQuality } from './imageQuality'
+
+jest.mock('tesseract.js', () => ({
+  __esModule: true,
+  default: {
+    recognize: jest.fn(() => Promise.reject(new Error('OCR failed')))
+  }
+}))
+
+test('deletes mats when analysis fails', async () => {
+  const mats = []
+  const matVectors = []
+
+  class Mat {
+    constructor () {
+      this.delete = jest.fn()
+      this.data64F = [0]
+      this.rows = 0
+      mats.push(this)
+    }
+  }
+
+  class MatVector {
+    constructor () {
+      this.delete = jest.fn()
+      this.size = () => 0
+      matVectors.push(this)
+    }
+  }
+
+  const cv = {
+    Mat,
+    MatVector,
+    Size: class {},
+    imread: jest.fn(() => new Mat()),
+    cvtColor: jest.fn(),
+    COLOR_RGBA2GRAY: 0,
+    Laplacian: jest.fn(),
+    CV_64F: 0,
+    meanStdDev: jest.fn((_, __, stddev) => {
+      stddev.data64F = [3]
+    }),
+    GaussianBlur: jest.fn(),
+    Canny: jest.fn(),
+    findContours: jest.fn(),
+    RETR_EXTERNAL: 0,
+    CHAIN_APPROX_SIMPLE: 0,
+    arcLength: jest.fn(),
+    approxPolyDP: jest.fn()
+  }
+
+  const originalWindow = global.window
+  global.window = { cv }
+
+  const result = await checkImageQuality({})
+  expect(result.error).toBe('OCR failed')
+  expect(mats).toHaveLength(7)
+  mats.forEach(m => expect(m.delete).toHaveBeenCalledTimes(1))
+  expect(matVectors).toHaveLength(1)
+  matVectors.forEach(mv => expect(mv.delete).toHaveBeenCalledTimes(1))
+
+  global.window = originalWindow
+})
+


### PR DESCRIPTION
## Summary
- ensure all OpenCV Mats and vectors are deleted via finally blocks
- add regression test for resource cleanup when OCR fails

## Testing
- `npx jest src/utils/imageQuality.test.js --env=node --watchAll=false`
- `npm test -- --watchAll=false` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install --save-dev jest-environment-jsdom@29.7.0` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68939726ebb48332ae557d6586e6ed82