### PR TITLE
fix: guard backend env test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,22 @@ LIST_ID=your‑list‑id
 
 At runtime the backend uses these values to obtain an access token via the client credentials grant and to talk to the Microsoft Graph API. See `backend/sharepointClient.js` for the implementation details. When deploying to production you should store secrets securely (e.g. Azure Key Vault) rather than committing them to source control.
 
+### Verify environment configuration
+
+To check that the required variables are present without printing their values, run:
+
+```bash
+cd backend
+node test-env.js
+```
+
+The script reports whether each variable is loaded. To print the actual values (except the client secret, which stays redacted) set an explicit debug flag:
+
+```bash
+cd backend
+DEBUG_ENV=true node test-env.js
+```
+
 ### API base URL
 
 The frontend looks for `VITE_API_BASE_URL` to know where the backend is running. When the variable is not set it defaults to `/api`.

--- a/backend/test-env.js
+++ b/backend/test-env.js
@@ -1,8 +1,19 @@
-require('dotenv').config();
+require('dotenv').config()
 
-console.log('Testing environment variables...');
-console.log('Tenant ID:', process.env.TENANT_ID);
-console.log('Client ID:', process.env.CLIENT_ID);
-console.log('Site ID:', process.env.SITE_ID);
-console.log('List ID:', process.env.LIST_ID);
-console.log('Client Secret loaded:', process.env.CLIENT_SECRET ? 'Yes ✅' : 'No ❌');
+const debug = process.env.DEBUG_ENV === 'true'
+
+console.log('Testing environment variables...')
+
+const logVar = (label, value, { alwaysHidden } = {}) => {
+  if (debug && !alwaysHidden) {
+    console.log(`${label}:`, value)
+  } else {
+    console.log(`${label} loaded:`, value ? 'Yes ✅' : 'No ❌')
+  }
+}
+
+logVar('Tenant ID', process.env.TENANT_ID)
+logVar('Client ID', process.env.CLIENT_ID)
+logVar('Site ID', process.env.SITE_ID)
+logVar('List ID', process.env.LIST_ID)
+logVar('Client Secret', process.env.CLIENT_SECRET, { alwaysHidden: true })


### PR DESCRIPTION
## Summary
- avoid logging raw env variables unless DEBUG_ENV=true
- explain safe env validation in README

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_b_6893a2aa91708332a79efbea6601f194