### PR TITLE
feat: add receipt processing microservice

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,59 @@
+import json
+import cgi
+from pathlib import Path
+
+FIELD_MAPPING_PATH = Path(__file__).resolve().parent.parent / 'backend' / 'fieldMapping.json'
+with FIELD_MAPPING_PATH.open() as f:
+  FIELD_MAPPING = json.load(f)
+
+USER_LIST = [
+  {'id': '1', 'displayName': 'Alice'},
+  {'id': '2', 'displayName': 'Bob'}
+]
+
+def app(environ, start_response):
+  method = environ.get('REQUEST_METHOD', 'GET')
+  path = environ.get('PATH_INFO', '/')
+
+  if method == 'GET' and path == '/fields':
+    start_response('200 OK', [('Content-Type', 'application/json')])
+    return [json.dumps(FIELD_MAPPING).encode()]
+
+  if method == 'GET' and path == '/users':
+    start_response('200 OK', [('Content-Type', 'application/json')])
+    return [json.dumps(USER_LIST).encode()]
+
+  if method == 'POST' and path == '/upload':
+    form = cgi.FieldStorage(fp=environ['wsgi.input'], environ=environ, keep_blank_values=True)
+    files = form['files'] if 'files' in form else []
+    if not isinstance(files, list):
+      files = [files]
+    if not files or all(not f.filename for f in files):
+      start_response('400 Bad Request', [('Content-Type', 'application/json')])
+      return [json.dumps({'error': 'No files uploaded'}).encode()]
+    data = [{'success': True, 'data': {'filename': f.filename}} for f in files if f.filename]
+    start_response('200 OK', [('Content-Type', 'application/json')])
+    return [json.dumps(data).encode()]
+
+  if method == 'POST' and path == '/submit':
+    try:
+      length = int(environ.get('CONTENT_LENGTH') or 0)
+    except (ValueError):
+      length = 0
+    body = environ['wsgi.input'].read(length) if length else b'{}'
+    try:
+      payload = json.loads(body)
+    except json.JSONDecodeError:
+      payload = {}
+    start_response('200 OK', [('Content-Type', 'application/json')])
+    return [json.dumps({'success': True, 'received': payload}).encode()]
+
+  start_response('404 Not Found', [('Content-Type', 'application/json')])
+  return [json.dumps({'error': 'Not found'}).encode()]
+
+if __name__ == '__main__':
+  from wsgiref.simple_server import make_server
+
+  with make_server('', 8000, app) as server:
+    print('Serving on http://localhost:8000')
+    server.serve_forever()

--- a/api/tests/test_api_endpoints.py
+++ b/api/tests/test_api_endpoints.py
@@ -1,0 +1,77 @@
+import json
+from io import BytesIO
+from wsgiref.util import setup_testing_defaults
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+from api.app import app
+
+
+def wsgi_request(method, path, body=b'', headers=None):
+  env = {}
+  setup_testing_defaults(env)
+  env['REQUEST_METHOD'] = method
+  env['PATH_INFO'] = path
+  env['CONTENT_LENGTH'] = str(len(body))
+  env['wsgi.input'] = BytesIO(body)
+  if headers:
+    env.update(headers)
+  result = {}
+
+  def start_response(status, response_headers):
+    result['status'] = status
+    result['headers'] = response_headers
+
+  resp = app(env, start_response)
+  data = b''.join(resp)
+  status_code = int(result['status'].split()[0])
+  return status_code, dict(result['headers']), data
+
+
+def test_get_fields():
+  status, _, body = wsgi_request('GET', '/fields')
+  assert status == 200
+  assert isinstance(json.loads(body), list)
+
+
+def test_get_users():
+  status, _, body = wsgi_request('GET', '/users')
+  assert status == 200
+  users = json.loads(body)
+  assert users[0]['displayName'] == 'Alice'
+
+
+def test_upload_requires_file():
+  boundary = 'BOUND'
+  body = f'--{boundary}--\r\n'.encode()
+  headers = {'CONTENT_TYPE': f'multipart/form-data; boundary={boundary}'}
+  status, _, body = wsgi_request('POST', '/upload', body, headers)
+  assert status == 400
+  assert 'No files' in json.loads(body)['error']
+
+
+def test_upload_returns_filename():
+  boundary = 'BOUND'
+  file_content = b'hello'
+  body = (
+    f'--{boundary}\r\n'
+    'Content-Disposition: form-data; name="files"; filename="test.txt"\r\n'
+    'Content-Type: text/plain\r\n\r\n'
+  ).encode() + file_content + f'\r\n--{boundary}--\r\n'.encode()
+  headers = {'CONTENT_TYPE': f'multipart/form-data; boundary={boundary}'}
+  status, _, body = wsgi_request('POST', '/upload', body, headers)
+  assert status == 200
+  data = json.loads(body)
+  assert data[0]['data']['filename'] == 'test.txt'
+
+
+def test_submit_endpoint():
+  payload = {'fields': {'title': 'T'}, 'attachments': [], 'signature': ''}
+  body = json.dumps(payload).encode()
+  headers = {'CONTENT_TYPE': 'application/json'}
+  status, _, body = wsgi_request('POST', '/submit', body, headers)
+  assert status == 200
+  resp = json.loads(body)
+  assert resp['success']
+  assert resp['received']['fields']['title'] == 'T'


### PR DESCRIPTION
## Summary
- build Python WSGI microservice with endpoints for fields, users, upload, and submit
- cover endpoints with tests exercising request handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6893a5dc5880833295900d0964bf8478