### PR TITLE
feat: add Azure Document Intelligence client

### DIFF
--- a/backend/__tests__/server.test.js
+++ b/backend/__tests__/server.test.js
@@ -4,6 +4,8 @@ jest.mock('../sharepointClient', () => ({
   listActiveUsers: jest.fn(() => Promise.resolve([])),
 }))
 const { createPurchaseRequisition } = require('../sharepointClient')
+process.env.AZURE_DOC_INTELLIGENCE_ENDPOINT = 'https://example.com'
+process.env.AZURE_DOC_INTELLIGENCE_KEY = 'test-key'
 const app = require('../server')
 const fieldMapping = require('../fieldMapping.json')
 

--- a/backend/__tests__/upload.test.js
+++ b/backend/__tests__/upload.test.js
@@ -4,6 +4,8 @@ jest.mock('tesseract.js', () => ({
   recognize: jest.fn(() => Promise.resolve({ data: { text: '' } })),
 }))
 
+process.env.AZURE_DOC_INTELLIGENCE_ENDPOINT = 'https://example.com'
+process.env.AZURE_DOC_INTELLIGENCE_KEY = 'test-key'
 const app = require('../server')
 
 describe('upload multiple files', () => {

--- a/backend/docIntelligenceClient.js
+++ b/backend/docIntelligenceClient.js
@@ -1,0 +1,30 @@
+const fetch = require('node-fetch')
+
+const endpoint = process.env.AZURE_DOC_INTELLIGENCE_ENDPOINT
+const key = process.env.AZURE_DOC_INTELLIGENCE_KEY
+
+async function analyzeDocument (file, model) {
+  const url = `${endpoint}/formrecognizer/documentModels/${model}:analyze?api-version=2023-07-31`
+  console.log(`Analyzing document with model ${model}`)
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'Ocp-Apim-Subscription-Key': key
+      },
+      body: file
+    })
+    if (!res.ok) {
+      const errText = await res.text()
+      console.error('Document Intelligence API error', res.status, errText)
+      throw new Error(errText || 'Request failed')
+    }
+    return await res.json()
+  } catch (err) {
+    console.error('Document Intelligence request failed', err.message)
+    throw err
+  }
+}
+
+module.exports = { analyzeDocument }

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,8 @@
     "express": "^4.18.2",
     "multer": "2.0.2",
     "tesseract.js": "^4.0.2",
-    "isomorphic-fetch": "^3.0.0"
+    "isomorphic-fetch": "^3.0.0",
+    "node-fetch": "^2.6.12"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,5 +1,16 @@
-require('dotenv').config();
-const express = require('express');
+require('dotenv').config()
+
+const {
+  AZURE_DOC_INTELLIGENCE_ENDPOINT,
+  AZURE_DOC_INTELLIGENCE_KEY
+} = process.env
+
+if (!AZURE_DOC_INTELLIGENCE_ENDPOINT || !AZURE_DOC_INTELLIGENCE_KEY) {
+  console.error('Missing Azure Document Intelligence configuration')
+  process.exit(1)
+}
+
+const express = require('express')
 const cors = require('cors');
 const multer = require('multer');
 const Tesseract = require('tesseract.js');


### PR DESCRIPTION
## Summary
- fail fast when Azure Document Intelligence env vars missing
- add wrapper for Azure Document Intelligence analyze endpoint
- declare node-fetch dependency for backend

## Testing
- `npm install node-fetch@2 --registry=https://registry.npmjs.org` *(fails: 403 Forbidden)*
- `cd backend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_6893abf2e28c83328c14afa0a7b4f763