### PR TITLE
feat: add content type submission

### DIFF
--- a/backend/__tests__/server.test.js
+++ b/backend/__tests__/server.test.js
@@ -1,10 +1,10 @@
 const request = require('supertest')
 jest.mock('../sharepointClient', () => ({
-  createPurchaseRequisition: jest.fn(() => Promise.resolve({ id: 'item' })),
+  createItemWithContentType: jest.fn(() => Promise.resolve({ id: 'item' })),
   listActiveUsers: jest.fn(() => Promise.resolve([])),
   listContentTypes: jest.fn(() => Promise.resolve([])),
 }))
-const { createPurchaseRequisition } = require('../sharepointClient')
+const { createItemWithContentType } = require('../sharepointClient')
 process.env.AZURE_DOC_INTELLIGENCE_ENDPOINT = 'https://example.com'
 process.env.AZURE_DOC_INTELLIGENCE_KEY = 'test-key'
 const app = require('../server')
@@ -25,7 +25,7 @@ describe('server routes', () => {
   it('submits stub data', async () => {
     const res = await request(app)
       .post('/api/submit')
-      .send({ fields: {}, attachments: [], signature: null })
+      .send({ fields: {}, attachments: [], signature: null, contentTypeId: 'ct' })
     expect(res.status).toBe(200)
     expect(res.body.success).toBe(true)
   })
@@ -38,12 +38,12 @@ describe('server routes', () => {
     }
     const res = await request(app)
       .post('/api/submit')
-      .send({ fields: {}, attachments: [attachment], signature: null })
+      .send({ fields: {}, attachments: [attachment], signature: null, contentTypeId: 'ct' })
     expect(res.status).toBe(200)
-    expect(createPurchaseRequisition).toHaveBeenCalledWith(
+    expect(createItemWithContentType).toHaveBeenCalledWith(
       {},
       [attachment],
-      null
+      'ct'
     )
   })
 

--- a/frontend/src/pages/SubmitPage.jsx
+++ b/frontend/src/pages/SubmitPage.jsx
@@ -29,12 +29,22 @@ export default function SubmitPage() {
             })
         )
       )
-      await axios.post(`${API_BASE_URL}/submit`, {
+      const res = await axios.post(`${API_BASE_URL}/submit`, {
         fields: receipt.fields,
         attachments,
         signature: receipt.signature,
+        contentTypeId: receipt.contentTypeId,
       })
       setSuccess(true)
+      const itemId = res.data?.id
+      if (itemId) {
+        const siteUrl = import.meta.env.VITE_SHAREPOINT_SITE_URL
+        const listId = import.meta.env.VITE_SHAREPOINT_LIST_ID
+        if (siteUrl && listId) {
+          const editUrl = `${siteUrl}/_layouts/15/listform.aspx?PageType=6&ListId=${listId}&ID=${itemId}`
+          window.location.href = editUrl
+        }
+      }
     } catch (e) {
       console.error(e)
       setError(e.response?.data?.error || e.message)


### PR DESCRIPTION
## Summary
- add SharePoint item creator that sets a chosen content type
- forward content type selection through submit API
- redirect users to SharePoint edit form after item creation

## Testing
- `cd backend && npx jest --runInBand`
- `cd frontend && npm test -- --watchAll=false` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_b_6893b825cb60833294063a1d95f867f1