### PR TITLE
feat: cache content types

### DIFF
--- a/frontend/src/context/ReceiptContext.jsx
+++ b/frontend/src/context/ReceiptContext.jsx
@@ -1,10 +1,10 @@
-import React, { createContext, useState } from 'react';
+import React, { createContext, useState, useEffect } from 'react'
 
 // Context for storing the current requisition state.  Fields map to the stateKey
 // values defined in backend/fieldMapping.json.  Attachments is an array of
 // File objects, and signature is a base64 data URL.
 
-export const ReceiptContext = createContext(null);
+export const ReceiptContext = createContext(null)
 
 export function ReceiptProvider({ children }) {
   const [receipt, setReceipt] = useState({
@@ -13,11 +13,33 @@ export function ReceiptProvider({ children }) {
     signature: null,
     contentTypeId: null,
     contentTypeName: '',
-  });
+  })
+
+  const [contentTypes, setContentTypes] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('contentTypes')
+      if (stored) {
+        try {
+          return JSON.parse(stored)
+        } catch {
+          return []
+        }
+      }
+    }
+    return []
+  })
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('contentTypes', JSON.stringify(contentTypes))
+    }
+  }, [contentTypes])
 
   return (
-    <ReceiptContext.Provider value={{ receipt, setReceipt }}>
+    <ReceiptContext.Provider
+      value={{ receipt, setReceipt, contentTypes, setContentTypes }}
+    >
       {children}
     </ReceiptContext.Provider>
-  );
+  )
 }

--- a/frontend/src/pages/UploadPage.jsx
+++ b/frontend/src/pages/UploadPage.jsx
@@ -8,14 +8,14 @@ import { QUALITY_MESSAGES } from '../utils/qualityMessages'
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
 
 export default function UploadPage() {
-  const { receipt, setReceipt } = useContext(ReceiptContext)
+  const { receipt, setReceipt, contentTypes, setContentTypes } =
+    useContext(ReceiptContext)
   const navigate = useNavigate()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
   const [inputKey, setInputKey] = useState(0)
   const [readyAttachments, setReadyAttachments] = useState([])
   const [previewUrls, setPreviewUrls] = useState([])
-  const [contentTypes, setContentTypes] = useState([])
   const [selectedContentType, setSelectedContentType] = useState(null)
 
   useEffect(() => {
@@ -60,7 +60,7 @@ export default function UploadPage() {
         : resp.data.data || {}
       const normalizeKeys = (obj) =>
         Object.fromEntries(
-          Object.entries(obj).map(([k, v]) => [k.replace('[i]', '[0]'), v])
+          Object.entries(obj).map(([k, v]) => [k.replace('[i]', '[0]'), v]),
         )
       const fields = normalizeKeys(rawFields)
       setReceipt({
@@ -69,8 +69,10 @@ export default function UploadPage() {
         attachments: [...(receipt.attachments || []), ...readyAttachments],
       })
       setReadyAttachments([])
-      const ctRes = await axios.get(`${API_BASE_URL}/content-types`)
-      setContentTypes(ctRes.data || [])
+      if (!contentTypes.length) {
+        const ctRes = await axios.get(`${API_BASE_URL}/content-types`)
+        setContentTypes(ctRes.data || [])
+      }
     } catch (err) {
       console.error(err)
       setError({
@@ -84,9 +86,7 @@ export default function UploadPage() {
 
   const handleContentTypeChange = (e) => {
     const id = e.target.value
-    const ct = contentTypes.find(
-      (c) => (c.Id?.StringValue || c.Id) === id
-    )
+    const ct = contentTypes.find((c) => (c.Id?.StringValue || c.Id) === id)
     setSelectedContentType(ct)
     setReceipt((prev) => ({
       ...prev,


### PR DESCRIPTION
## Summary
- persist content types in ReceiptContext and localStorage
- use cached content types on upload to avoid redundant API calls

## Testing
- `npm test -- --watchAll=false` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_b_6893c2858528833290f6306e8702dc69