### PR TITLE
feat: retry Document Intelligence requests

### DIFF
--- a/backend/docIntelligenceClient.js
+++ b/backend/docIntelligenceClient.js
@@ -3,27 +3,48 @@ const fetch = require('node-fetch')
 const endpoint = process.env.AZURE_DOC_INTELLIGENCE_ENDPOINT
 const key = process.env.AZURE_DOC_INTELLIGENCE_KEY
 
-async function analyzeDocument (file, model, contentType) {
+async function analyzeDocument(file, model, contentType) {
   const url = `${endpoint}/formrecognizer/documentModels/${model}:analyze?api-version=2023-07-31`
   console.log(`Analyzing document with model ${model}`)
-  try {
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': contentType,
-        'Ocp-Apim-Subscription-Key': key
-      },
-      body: file
-    })
-    if (!res.ok) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': contentType,
+          'Ocp-Apim-Subscription-Key': key
+        },
+        body: file
+      })
+
+      if (res.ok) return await res.json()
+
+      if (res.status === 429 || res.status === 503) {
+        if (attempt < 2) {
+          const delay = 500 * 2 ** attempt
+          console.warn(
+            `Retrying document analysis, attempt ${attempt + 2} after ${res.status}`
+          )
+          await new Promise((resolve) => setTimeout(resolve, delay))
+          continue
+        }
+      }
+
       const errText = await res.text()
       console.error('Document Intelligence API error', res.status, errText)
       throw new Error(errText || 'Request failed')
+    } catch (err) {
+      if (attempt < 2) {
+        const delay = 500 * 2 ** attempt
+        console.warn(
+          `Retrying document analysis, attempt ${attempt + 2} after error: ${err.message}`
+        )
+        await new Promise((resolve) => setTimeout(resolve, delay))
+      } else {
+        console.error('Document Intelligence request failed', err.message)
+        throw err
+      }
     }
-    return await res.json()
-  } catch (err) {
-    console.error('Document Intelligence request failed', err.message)
-    throw err
   }
 }
 


### PR DESCRIPTION
## Summary
- retry Document Intelligence API requests up to three times
- exponential backoff on 429/503 responses
- log each retry attempt and surface an error after retries fail

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_6893c5d5a5e0833294fdb54edad5c44d