### PR TITLE
feat: load field mappings by content type

### DIFF
--- a/api/tests/test_api_endpoints.py
+++ b/api/tests/test_api_endpoints.py
@@ -29,10 +29,24 @@ def wsgi_request(method, path, body=b'', headers=None):
   return status_code, dict(result['headers']), data
 
 
-def test_get_fields():
+def test_get_fields_default():
   status, _, body = wsgi_request('GET', '/fields')
   assert status == 200
-  assert isinstance(json.loads(body), list)
+  fields = json.loads(body)
+  assert any(f['stateKey'] == 'vendorName' for f in fields)
+
+
+def test_get_fields_content_type():
+  status, _, body = wsgi_request('GET', '/fields', headers={'QUERY_STRING': 'contentType=tcfv-card'})
+  assert status == 200
+  fields = json.loads(body)
+  assert fields[0]['stateKey'] == 'fieldA'
+
+
+def test_get_fields_invalid_content_type():
+  status, _, body = wsgi_request('GET', '/fields', headers={'QUERY_STRING': 'contentType=unknown'})
+  assert status == 400
+  assert 'unsupported contentType' in json.loads(body)['error']
 
 
 def test_get_users():

--- a/backend/fieldMappings/personal-card.json
+++ b/backend/fieldMappings/personal-card.json
@@ -1,0 +1,19 @@
+{
+  "contentType": "Personal Card",
+  "model": "prebuilt-document",
+  "confidenceThreshold": 0.75,
+  "fields": [
+    {
+      "diField": "FieldB",
+      "spInternalName": "FieldB",
+      "label": "Field B",
+      "stateKey": "fieldB",
+      "dataType": "string",
+      "required": true,
+      "validation": "non-empty",
+      "transformation": null,
+      "confidence": 0.75
+    }
+  ]
+}
+

--- a/backend/fieldMappings/tcfv-card.json
+++ b/backend/fieldMappings/tcfv-card.json
@@ -1,0 +1,19 @@
+{
+  "contentType": "TCFV Card",
+  "model": "prebuilt-document",
+  "confidenceThreshold": 0.75,
+  "fields": [
+    {
+      "diField": "FieldA",
+      "spInternalName": "FieldA",
+      "label": "Field A",
+      "stateKey": "fieldA",
+      "dataType": "string",
+      "required": true,
+      "validation": "non-empty",
+      "transformation": null,
+      "confidence": 0.75
+    }
+  ]
+}
+


### PR DESCRIPTION
## Summary
- support multiple field mappings by content type
- add sample mappings for tcfv-card and personal-card
- test field retrieval for valid and invalid contentType values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6893d7e61c6083328ade473fbf97dae1