### PR TITLE
feat: add content type mapping

### DIFF
--- a/frontend/src/pages/ReviewPage.jsx
+++ b/frontend/src/pages/ReviewPage.jsx
@@ -2,11 +2,13 @@ import React, { useContext, useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import axios from 'axios'
 import { ReceiptContext } from '../context/ReceiptContext.jsx'
+import { mapContentType } from '../utils/mapContentType'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
 
 export default function ReviewPage() {
   const { receipt, setReceipt } = useContext(ReceiptContext)
+  const contentType = mapContentType(receipt.contentTypeName)
   const [mapping, setMapping] = useState([])
   const [errors, setErrors] = useState({})
   const navigate = useNavigate()
@@ -16,14 +18,16 @@ export default function ReviewPage() {
     // Fetch field mapping from backend so the form knows which fields to display.
     async function loadMapping() {
       try {
-        const res = await axios.get(`${API_BASE_URL}/fields`)
+        const res = await axios.get(`${API_BASE_URL}/fields`, {
+          params: { contentType },
+        })
         setMapping(res.data)
       } catch (e) {
         console.error('Failed to load field mapping', e)
       }
     }
     loadMapping()
-  }, [])
+  }, [contentType])
 
   const handleChange = (key, value) => {
     setReceipt(prev => ({

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -1,3 +1,4 @@
 export * from './imageQuality'
 export * from './qualityMessages'
 export * from './getDocumentModel'
+export * from './mapContentType'

--- a/frontend/src/utils/mapContentType.js
+++ b/frontend/src/utils/mapContentType.js
@@ -1,0 +1,8 @@
+export function mapContentType(name) {
+  const mapping = {
+    'Purchase Requisition - Vendor Invoice': 'vendor-invoice',
+    'Purchase Requisition - TCFV Card': 'tcfv-card',
+    'Purchase Requisition - Personal Card': 'personal-card',
+  }
+  return mapping[name] || 'vendor-invoice'
+}


### PR DESCRIPTION
## Summary
- map receipt content type names to backend slugs
- query fields with mapped content type on review page

## Testing
- `npm test -- --watchAll=false` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_b_6893da38d1008332a0311d0e29c25b17