### PR TITLE
feat: add document field transformation utilities

### DIFF
--- a/backend/__tests__/transformUtils.test.js
+++ b/backend/__tests__/transformUtils.test.js
@@ -1,0 +1,72 @@
+const {
+  currencyToFloat,
+  dateToISO,
+  extractLineItems,
+  applyTransformations
+} = require('../transformUtils')
+
+describe('currencyToFloat', () => {
+  test('parses currency formatted strings', () => {
+    expect(currencyToFloat('$1,234.56')).toBeCloseTo(1234.56)
+    expect(currencyToFloat('€987,654')).toBe(987654)
+  })
+})
+
+describe('dateToISO', () => {
+  test('normalizes common date formats', () => {
+    expect(dateToISO('08/06/2025')).toBe('2025-08-06')
+    expect(dateToISO('2025-08-06')).toBe('2025-08-06')
+    expect(dateToISO('Aug 6, 2025')).toBe('2025-08-06')
+  })
+})
+
+describe('extractLineItems', () => {
+  test('extracts rows from tables and applies transformations', () => {
+    const tables = [
+      {
+        rowCount: 3,
+        columnCount: 3,
+        cells: [
+          { rowIndex: 0, columnIndex: 0, content: 'Date' },
+          { rowIndex: 0, columnIndex: 1, content: 'Item Description' },
+          { rowIndex: 0, columnIndex: 2, content: 'Total' },
+          { rowIndex: 1, columnIndex: 0, content: '08/06/2025' },
+          { rowIndex: 1, columnIndex: 1, content: 'Item A' },
+          { rowIndex: 1, columnIndex: 2, content: '$10.00' },
+          { rowIndex: 2, columnIndex: 0, content: '08/07/2025' },
+          { rowIndex: 2, columnIndex: 1, content: 'Item B' },
+          { rowIndex: 2, columnIndex: 2, content: '$20.00' }
+        ]
+      }
+    ]
+
+    const mapping = {
+      columns: [
+        { name: 'Date', transformation: 'dateToISO' },
+        { name: 'Item Description' },
+        { name: 'Total', transformation: 'currencyToFloat' }
+      ]
+    }
+
+    const items = extractLineItems(tables, mapping)
+    expect(items).toEqual([
+      { Date: '2025-08-06', 'Item Description': 'Item A', Total: 10 },
+      { Date: '2025-08-07', 'Item Description': 'Item B', Total: 20 }
+    ])
+  })
+})
+
+describe('applyTransformations', () => {
+  test('applies transformations based on mapping', () => {
+    const fieldMap = [
+      { stateKey: 'amount', transformation: 'currencyToFloat' },
+      { stateKey: 'when', transformation: 'dateToISO' }
+    ]
+    const data = { amount: '$1,234.50', when: 'Aug 6, 2025' }
+    expect(applyTransformations(fieldMap, data)).toEqual({
+      amount: 1234.5,
+      when: '2025-08-06'
+    })
+  })
+})
+

--- a/backend/transformUtils.js
+++ b/backend/transformUtils.js
@@ -1,0 +1,74 @@
+const symbolRegex = /[^\d.-]/g
+
+function currencyToFloat(value) {
+  if (value == null) return value
+  const cleaned = String(value).replace(symbolRegex, '')
+  const parsed = parseFloat(cleaned)
+  return isNaN(parsed) ? null : parsed
+}
+
+function dateToISO(value) {
+  if (!value) return value
+  const date = new Date(value)
+  if (!isNaN(date)) {
+    return date.toISOString().slice(0, 10)
+  }
+  const match = value.match(/^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/)
+  if (match) {
+    let [, m, d, y] = match
+    if (y.length === 2) y = '20' + y
+    return `${y}-${m.padStart(2, '0')}-${d.padStart(2, '0')}`
+  }
+  return value
+}
+
+function applyTransformations(fieldMap, data) {
+  const transformers = { currencyToFloat, dateToISO }
+  fieldMap.forEach((field) => {
+    if (!field.transformation) return
+    const key = field.stateKey || field.name
+    if (data[key] == null) return
+    const fn = transformers[field.transformation]
+    if (fn) data[key] = fn(data[key])
+  })
+  return data
+}
+
+function extractLineItems(tables, mapping) {
+  if (!tables || !Array.isArray(tables) || !mapping?.columns) return []
+  const items = []
+  tables.forEach((table) => {
+    const rows = Array.from({ length: table.rowCount }, () => [])
+    table.cells.forEach((cell) => {
+      rows[cell.rowIndex][cell.columnIndex] = cell.content
+    })
+    const header = rows[0]?.map((h) => h && h.trim().toLowerCase()) || []
+    const indexMap = {}
+    mapping.columns.forEach((col) => {
+      const idx = header.findIndex(
+        (h) => h && h.includes(col.name.trim().toLowerCase())
+      )
+      if (idx !== -1) indexMap[col.name] = idx
+    })
+    for (let i = 1; i < rows.length; i++) {
+      const row = rows[i]
+      const item = {}
+      Object.entries(indexMap).forEach(([name, idx]) => {
+        const val = row[idx]
+        if (val != null) item[name] = val
+      })
+      if (Object.keys(item).length) {
+        items.push(applyTransformations(mapping.columns, item))
+      }
+    }
+  })
+  return items
+}
+
+module.exports = {
+  currencyToFloat,
+  dateToISO,
+  extractLineItems,
+  applyTransformations
+}
+


### PR DESCRIPTION
## Summary
- add currency parsing and date normalization helpers
- provide line item extraction from Document Intelligence tables
- expose applyTransformations helper and tests

## Testing
- `npx jest __tests__/sharepointClient.test.js __tests__/server.test.js __tests__/transformUtils.test.js __tests__/upload.test.js --runInBand --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_6893ddc6cf708332a2e80f19009ca1b9