### PR TITLE
feat: apply content-type field mappings during upload

### DIFF
--- a/backend/__tests__/upload.test.js
+++ b/backend/__tests__/upload.test.js
@@ -6,8 +6,26 @@ jest.mock('../docIntelligenceClient', () => ({
       documents: [
         {
           fields: {
-            MerchantName: { content: 'Shop', confidence: 0.8 }
+            VendorName: { content: 'Vendor Inc', confidence: 0.8 },
+            InvoiceTotal: { content: '$10.00', confidence: 0.8 },
+            InvoiceDate: { content: '08/06/2025', confidence: 0.8 },
+            VendorAddress: { content: '', confidence: 0.9 },
+            InvoiceId: { content: '123', confidence: 0.6 }
           }
+        }
+      ],
+      tables: [
+        {
+          rowCount: 2,
+          columnCount: 3,
+          cells: [
+            { rowIndex: 0, columnIndex: 0, content: 'Date' },
+            { rowIndex: 0, columnIndex: 1, content: 'Invoice #' },
+            { rowIndex: 0, columnIndex: 2, content: 'Total' },
+            { rowIndex: 1, columnIndex: 0, content: '08/06/2025' },
+            { rowIndex: 1, columnIndex: 1, content: 'INV-1' },
+            { rowIndex: 1, columnIndex: 2, content: '$10.00' }
+          ]
         }
       ]
     })
@@ -19,16 +37,25 @@ process.env.AZURE_DOC_INTELLIGENCE_KEY = 'test-key'
 const app = require('../server')
 
 describe('upload multiple files', () => {
-  it('returns results for each file', async () => {
+  it('applies field mapping and transformations', async () => {
     const res = await request(app)
       .post('/api/upload')
-      .field('selectedContentType', JSON.stringify({ Name: 'Receipt' }))
+      .field(
+        'selectedContentType',
+        JSON.stringify({ Name: 'Purchase Requisition - Vendor Invoice' })
+      )
       .attach('files', Buffer.from('one'), 'one.png')
-      .attach('files', Buffer.from('two'), 'two.png')
     expect(res.status).toBe(200)
     expect(Array.isArray(res.body)).toBe(true)
-    expect(res.body).toHaveLength(2)
-    expect(res.body[0].data.MerchantName).toBe('Shop')
-    expect(res.body[0].confidence.MerchantName).toBe(0.8)
+    expect(res.body).toHaveLength(1)
+    const first = res.body[0]
+    expect(first.data.vendorName).toBe('Vendor Inc')
+    expect(first.data.grandTotal).toBe(10)
+    expect(first.data.invoiceDate).toBe('2025-08-06')
+    expect(first.confidence.vendorName).toBe(0.8)
+    expect(first.data.vendorAddress).toBeUndefined()
+    expect(first.data.invoiceId).toBeUndefined()
+    expect(first.data.lineItems[0].Date).toBe('2025-08-06')
+    expect(first.data.lineItems[0].Total).toBe(10)
   })
 })


### PR DESCRIPTION
## Summary
- load field mappings for selected content type and validate confidences
- transform and validate field and line item data during upload
- test upload handler with mapping and line item extraction

## Testing
- `npm test -- --runInBand --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_6893e07f3b808332a8597265c85ac1d5