### PR TITLE
feat: add tcfv card receipt mapping

### DIFF
--- a/api/tests/test_api_endpoints.py
+++ b/api/tests/test_api_endpoints.py
@@ -40,7 +40,7 @@ def test_get_fields_content_type():
   status, _, body = wsgi_request('GET', '/fields', headers={'QUERY_STRING': 'contentType=tcfv-card'})
   assert status == 200
   fields = json.loads(body)
-  assert fields[0]['stateKey'] == 'fieldA'
+  assert fields[0]['stateKey'] == 'vendorName'
 
 
 def test_get_fields_invalid_content_type():

--- a/backend/fieldMappings/tcfv-card.json
+++ b/backend/fieldMappings/tcfv-card.json
@@ -1,19 +1,62 @@
 {
-  "contentType": "TCFV Card",
-  "model": "prebuilt-document",
+  "contentType": "Purchase Requisition - TCFV Card",
+  "model": "prebuilt-receipt",
   "confidenceThreshold": 0.75,
   "fields": [
     {
-      "diField": "FieldA",
-      "spInternalName": "FieldA",
-      "label": "Field A",
-      "stateKey": "fieldA",
+      "diField": "MerchantName",
+      "spInternalName": "Vendor_x0020_Name_x0028_s_x0029",
+      "label": "Vendor Name(s)",
+      "stateKey": "vendorName",
       "dataType": "string",
       "required": true,
       "validation": "non-empty",
       "transformation": null,
       "confidence": 0.75
+    },
+    {
+      "diField": "TransactionDate",
+      "spInternalName": "Date_x0020_Submitted",
+      "label": "Date Submitted",
+      "stateKey": "transactionDate",
+      "dataType": "date",
+      "required": true,
+      "validation": "YYYY-MM-DD",
+      "transformation": "dateToISO",
+      "confidence": 0.75
+    },
+    {
+      "diField": "Total",
+      "spInternalName": "Grand_x0020_Total",
+      "label": "Grand Total",
+      "stateKey": "grandTotal",
+      "dataType": "currency",
+      "required": true,
+      "validation": "currency",
+      "transformation": "currencyToFloat",
+      "confidence": 0.75
+    },
+    {
+      "diField": "Subtotal",
+      "spInternalName": "SubtotalP",
+      "label": "Purchases Subtotal",
+      "stateKey": "subTotal",
+      "dataType": "currency",
+      "required": false,
+      "validation": "currency",
+      "transformation": "currencyToFloat",
+      "confidence": 0.75
+    },
+    {
+      "diField": "TotalTax",
+      "spInternalName": "TaxPTotal",
+      "label": "Total Tax",
+      "stateKey": "totalTax",
+      "dataType": "currency",
+      "required": false,
+      "validation": "currency",
+      "transformation": "currencyToFloat",
+      "confidence": 0.75
     }
   ]
 }
-


### PR DESCRIPTION
## Summary
- add TCFV card receipt mapping
- update API field retrieval test

## Testing
- `npm test -- --watchAll=false` *(fails: Missing script "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6893e74015b08332ba6633ed8b1ada99