### PR TITLE
fix: handle image load errors in file upload

### DIFF
--- a/frontend/src/components/FileUpload.jsx
+++ b/frontend/src/components/FileUpload.jsx
@@ -24,6 +24,10 @@ export default function FileUpload({ onFileSelected }) {
         URL.revokeObjectURL(img.src)
         resolve({ file, quality })
       }
+      img.onerror = () => {
+        URL.revokeObjectURL(img.src)
+        resolve({ file, quality: { error: 'Failed to load image' } })
+      }
       img.src = URL.createObjectURL(file)
     })
 


### PR DESCRIPTION
## Summary
- reject image load failures by resolving with error in `processFile`
- surface file processing errors in upload UI

## Testing
- `npm test -- --watchAll=false` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_b_68951340353083329a928e1f4c6aba94