### PR TITLE
perf: cache tesseract.js import

### DIFF
--- a/frontend/src/utils/imageQuality.js
+++ b/frontend/src/utils/imageQuality.js
@@ -10,6 +10,16 @@ const waitForOpenCV = (timeout = 5000) =>
     check()
   })
 
+let tesseractPromise
+
+const loadTesseract = () => {
+  if (!tesseractPromise)
+    tesseractPromise = import('tesseract.js').then(
+      ({ default: Tesseract }) => Tesseract
+    )
+  return tesseractPromise
+}
+
 export const checkImageQuality = async imageElement => {
   let mat, gray, laplacian, mean, stddev, edges, contours, hierarchy
   try {
@@ -49,7 +59,7 @@ export const checkImageQuality = async imageElement => {
       }
     }
 
-    const { default: Tesseract } = await import('tesseract.js')
+    const Tesseract = await loadTesseract()
     const {
       data: { confidence }
     } = await Tesseract.recognize(imageElement, 'eng')


### PR DESCRIPTION
## Summary
- cache the tesseract.js import in a module-level promise to reuse the OCR engine

## Testing
- `npm test -- --watchAll=false` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npm install --no-save jest-environment-jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_689518246ff48332b9bf196074a0cdfd