### PR TITLE
feat: upload attachments concurrently

### DIFF
--- a/backend/sharepointClient.js
+++ b/backend/sharepointClient.js
@@ -132,14 +132,16 @@ async function createPurchaseRequisition(fields, attachments, signature) {
       .post(itemPayload)
     // Upload attachments if provided
     if (attachments && attachments.length > 0) {
-      for (const file of attachments) {
-        const contentBytes = Buffer.from(file.content || '', 'base64')
-        await graph
-          .api(
-            `/sites/${siteId}/lists/${listId}/items/${item.id}/attachments/${file.name}/$value`,
-          )
-          .put(contentBytes)
-      }
+      await Promise.all(
+        attachments.map((file) => {
+          const contentBytes = Buffer.from(file.content || '', 'base64')
+          return graph
+            .api(
+              `/sites/${siteId}/lists/${listId}/items/${item.id}/attachments/${file.name}/$value`,
+            )
+            .put(contentBytes)
+        }),
+      )
     }
     return item
   } catch (err) {
@@ -177,14 +179,16 @@ async function createItemWithContentType(fields, attachments, contentTypeId) {
       .api(`/sites/${siteId}/lists/${listId}/items`)
       .post(itemPayload)
     if (attachments && attachments.length > 0) {
-      for (const file of attachments) {
-        const contentBytes = Buffer.from(file.content || '', 'base64')
-        await graph
-          .api(
-            `/sites/${siteId}/lists/${listId}/items/${item.id}/attachments/${file.name}/$value`,
-          )
-          .put(contentBytes)
-      }
+      await Promise.all(
+        attachments.map((file) => {
+          const contentBytes = Buffer.from(file.content || '', 'base64')
+          return graph
+            .api(
+              `/sites/${siteId}/lists/${listId}/items/${item.id}/attachments/${file.name}/$value`,
+            )
+            .put(contentBytes)
+        }),
+      )
     }
     return item
   } catch (err) {


### PR DESCRIPTION
## Summary
- upload SharePoint item attachments concurrently with Promise.all
- apply same concurrent logic to content type item creation

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_68951a7c87c88332b4f541a9dd9c93fd