### PR TITLE
refactor: simplify field mapping lookup

### DIFF
--- a/frontend/src/pages/ReviewPage.jsx
+++ b/frontend/src/pages/ReviewPage.jsx
@@ -2,13 +2,11 @@ import React, { useContext, useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import axios from 'axios'
 import { ReceiptContext } from '../context/ReceiptContext.jsx'
-import { mapContentType } from '../utils/mapContentType'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
 
 export default function ReviewPage() {
   const { receipt, setReceipt } = useContext(ReceiptContext)
-  const contentType = mapContentType(receipt.contentTypeName)
   const [mapping, setMapping] = useState([])
   const [errors, setErrors] = useState({})
   const [loading, setLoading] = useState(false)
@@ -25,9 +23,10 @@ export default function ReviewPage() {
       setErrors({})
       try {
         const res = await axios.get(`${API_BASE_URL}/fields`, {
-          params: { contentType },
+          params: { contentType: receipt.contentTypeName },
         })
-        setMapping(res.data)
+        const mapping = res.data.fields || res.data
+        setMapping(mapping)
       } catch (e) {
         console.error('Failed to load field mapping', e)
         setFetchError('Failed to load field mapping')
@@ -36,7 +35,7 @@ export default function ReviewPage() {
       }
     }
     loadMapping()
-  }, [contentType, receipt.contentTypeName])
+  }, [receipt.contentTypeName])
 
   const handleChange = (key, value) => {
     setReceipt((prev) => ({

--- a/frontend/src/utils/index.js
+++ b/frontend/src/utils/index.js
@@ -1,4 +1,3 @@
 export * from './imageQuality'
 export * from './qualityMessages'
 export * from './getDocumentModel'
-export * from './mapContentType'

--- a/frontend/src/utils/mapContentType.js
+++ b/frontend/src/utils/mapContentType.js
@@ -1,8 +1,0 @@
-export function mapContentType(name) {
-  const mapping = {
-    'Purchase Requisition - Vendor Invoice': 'vendor-invoice',
-    'Purchase Requisition - TCFV Card': 'tcfv-card',
-    'Purchase Requisition - Personal Card': 'personal-card',
-  }
-  return mapping[name] || 'vendor-invoice'
-}


### PR DESCRIPTION
## Summary
- remove content type mapping utility
- send `contentTypeName` directly when requesting field mapping and parse `fields` response

## Testing
- `npm test -- --watchAll=false` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_b_6895443b571c83329b666159bb69f343