### PR TITLE
fix: handle invalid contentType payload

### DIFF
--- a/backend/__tests__/upload.test.js
+++ b/backend/__tests__/upload.test.js
@@ -62,4 +62,13 @@ describe('upload multiple files', () => {
     expect(first.lineItems[0]['Invoice #']).toBe('INV-1')
     expect(first.lineItems[0].Total).toBe(10)
   })
+
+  it('returns 400 for invalid selectedContentType payload', async () => {
+    const res = await request(app)
+      .post('/api/upload')
+      .field('selectedContentType', '{ invalid')
+      .attach('files', Buffer.from('one'), 'one.png')
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({ error: 'Invalid contentType payload' })
+  })
 })

--- a/backend/server.js
+++ b/backend/server.js
@@ -130,8 +130,16 @@ app.post('/api/upload', (req, res) => {
           .json({ success: false, error: 'No files uploaded' })
       }
       const ctRaw = req.body.selectedContentType
-      const selectedContentType =
-        typeof ctRaw === 'string' ? JSON.parse(ctRaw) : ctRaw
+      let selectedContentType = ctRaw
+      if (typeof ctRaw === 'string') {
+        try {
+          selectedContentType = JSON.parse(ctRaw)
+        } catch (parseErr) {
+          return res
+            .status(400)
+            .json({ error: 'Invalid contentType payload' })
+        }
+      }
       const mapping = await loadFieldMapping(selectedContentType?.Name)
       const model =
         mapping?.model ||


### PR DESCRIPTION
## Summary
- validate selectedContentType payload to avoid invalid JSON parsing
- test upload rejects malformed content type

## Testing
- `npm test -- --watchAll=false --runInBand`


------
https://chatgpt.com/codex/tasks/task_b_689545ac29f883328e84dbac1f583494