### PR TITLE
feat: offload OCR to worker

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  testEnvironment: 'jsdom',
+  testEnvironment: 'node',
   transform: {
     '^.+\\.jsx?$': 'babel-jest'
   }

--- a/frontend/src/utils/ocrWorker.js
+++ b/frontend/src/utils/ocrWorker.js
@@ -1,0 +1,13 @@
+import Tesseract from 'tesseract.js'
+
+self.onmessage = async e => {
+  try {
+    const {
+      data: { confidence }
+    } = await Tesseract.recognize(e.data.image, 'eng')
+    self.postMessage({ confidence })
+  } catch (error) {
+    self.postMessage({ error: error.message || 'OCR failed' })
+  }
+}
+


### PR DESCRIPTION
## Summary
- handle OCR in a dedicated worker
- delegate image quality checks to worker for recognition
- adapt tests and Jest config for worker interface

## Testing
- `npm test -- --watchAll=false` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_68954959b2688332bdaeb554076b3ab7