### PR TITLE
feat: add configurable CORS whitelist

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,3 +17,6 @@ LIST_ID=
 
 # Port number for the backend API (optional).  Defaults to 5000.
 #PORT=5000
+
+# Comma-separated origins allowed to access the backend
+ALLOWED_ORIGINS=

--- a/backend/server.js
+++ b/backend/server.js
@@ -33,9 +33,7 @@ async function loadFieldMappings() {
     const files = await fs.readdir(dir)
     await Promise.all(
       files.map(async (file) => {
-        const json = JSON.parse(
-          await fs.readFile(path.join(dir, file), 'utf8')
-        )
+        const json = JSON.parse(await fs.readFile(path.join(dir, file), 'utf8'))
         if (json.contentType) fieldMappingsCache[json.contentType] = json
       }),
     )
@@ -89,7 +87,8 @@ const upload = multer({
   },
 })
 
-app.use(cors())
+const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',')
+app.use(cors({ origin: allowedOrigins }))
 app.use(express.json({ limit: '50mb' }))
 
 /**
@@ -135,9 +134,7 @@ app.post('/api/upload', (req, res) => {
         try {
           selectedContentType = JSON.parse(ctRaw)
         } catch (parseErr) {
-          return res
-            .status(400)
-            .json({ error: 'Invalid contentType payload' })
+          return res.status(400).json({ error: 'Invalid contentType payload' })
         }
       }
       const mapping = await loadFieldMapping(selectedContentType?.Name)


### PR DESCRIPTION
## Summary
- add ALLOWED_ORIGINS env var and use it for CORS whitelist in backend
- document ALLOWED_ORIGINS in backend .env.example

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_b_68962d41ddf48332a6000f9d5dd746da