### PR TITLE
refactor: use shared context providers

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,118 +1,105 @@
-import React, { createContext, useContext, useState, useEffect, useRef } from 'react';
-import logoUrl from './assets/logo.png';
-
-// === CONTEXTS ===
-const ReceiptContext = createContext(null);
-const UserContext = createContext(null);
-
-function ReceiptProvider({ children }) {
-  const [receipt, setReceipt] = useState({
-    fields: {},
-    attachments: [],
-    signature: null,
-    contentTypeId: null,
-    contentTypeName: '',
-  });
-  const [contentTypes, setContentTypes] = useState([]);
-
-  const resetReceipt = () => {
-    setReceipt({
-      fields: {},
-      attachments: [],
-      signature: null,
-      contentTypeId: null,
-      contentTypeName: '',
-    });
-  };
-
-  return (
-    <ReceiptContext.Provider
-      value={{ receipt, setReceipt, contentTypes, setContentTypes, resetReceipt }}
-    >
-      {children}
-    </ReceiptContext.Provider>
-  );
-}
-
-function UserProvider({ children }) {
-  const [user, setUser] = useState({ name: 'Demo User', email: 'demo@company.com' });
-  return <UserContext.Provider value={{ user, setUser }}>{children}</UserContext.Provider>;
-}
+import React, { useContext, useState } from "react"
+import logoUrl from "./assets/logo.png"
+import { ReceiptContext } from "./context/ReceiptContext.jsx"
+import { UserContext } from "./context/UserContext.jsx"
 
 // === UTILITY FUNCTIONS & CONSTANTS ===
 const QUALITY_MESSAGES = {
-  edges: 'Receipt edges not detected. Ensure entire receipt is visible and retry.',
-  blur: 'Image too blurry for OCR. Retake with better focus.',
-  ocr: 'Text too blurry for OCR. Retake in better lighting.',
-};
+  edges:
+    "Receipt edges not detected. Ensure entire receipt is visible and retry.",
+  blur: "Image too blurry for OCR. Retake with better focus.",
+  ocr: "Text too blurry for OCR. Retake in better lighting.",
+}
 
 const WORKFLOW_STEPS = [
-  { key: '/upload', label: 'Upload', icon: '📤' },
-  { key: '/review', label: 'Review', icon: '📝' },
-  { key: '/signature', label: 'Sign', icon: '✍️' },
-  { key: '/submit', label: 'Submit', icon: '🚀' },
-];
+  { key: "/upload", label: "Upload", icon: "📤" },
+  { key: "/review", label: "Review", icon: "📝" },
+  { key: "/signature", label: "Sign", icon: "✍️" },
+  { key: "/submit", label: "Submit", icon: "🚀" },
+]
 
 const normalizeKeys = (obj) =>
-  Object.fromEntries(Object.entries(obj).map(([k, v]) => [k.replaceAll('[i]', '[0]'), v]));
+  Object.fromEntries(
+    Object.entries(obj).map(([k, v]) => [k.replaceAll("[i]", "[0]"), v]),
+  )
 
 // === MOCK API ===
 const mockAPI = {
   async upload(shouldFail = false) {
-    await new Promise((resolve) => setTimeout(resolve, 2000));
-    if (shouldFail) throw new Error('Network error: Unable to process files');
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+    if (shouldFail) throw new Error("Network error: Unable to process files")
     return {
       data: {
-        'vendorName[0]': 'Demo Vendor Inc.',
-        'amount[0]': '125.50',
-        'date[0]': '2025-08-08',
-        'description[0]': 'Office supplies and equipment',
+        "vendorName[0]": "Demo Vendor Inc.",
+        "amount[0]": "125.50",
+        "date[0]": "2025-08-08",
+        "description[0]": "Office supplies and equipment",
       },
-    };
+    }
   },
   async getContentTypes() {
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    await new Promise((resolve) => setTimeout(resolve, 500))
     return {
       data: [
-        { Id: 'expense', Name: 'Expense Report' },
-        { Id: 'purchase', Name: 'Purchase Order' },
-        { Id: 'invoice', Name: 'Invoice' },
-        { Id: 'travel', Name: 'Travel Expense' },
+        { Id: "expense", Name: "Expense Report" },
+        { Id: "purchase", Name: "Purchase Order" },
+        { Id: "invoice", Name: "Invoice" },
+        { Id: "travel", Name: "Travel Expense" },
       ],
-    };
+    }
   },
   async getFields(contentType) {
-    await new Promise((resolve) => setTimeout(resolve, 800));
+    await new Promise((resolve) => setTimeout(resolve, 800))
     return {
       data: {
         fields: [
-          { stateKey: 'vendorName[i]', label: 'Vendor Name', dataType: 'string', required: true },
-          { stateKey: 'amount[i]', label: 'Amount ($)', dataType: 'number', required: true },
-          { stateKey: 'date[i]', label: 'Date', dataType: 'date', required: true },
-          { stateKey: 'description[i]', label: 'Description', dataType: 'text', required: false },
+          {
+            stateKey: "vendorName[i]",
+            label: "Vendor Name",
+            dataType: "string",
+            required: true,
+          },
+          {
+            stateKey: "amount[i]",
+            label: "Amount ($)",
+            dataType: "number",
+            required: true,
+          },
+          {
+            stateKey: "date[i]",
+            label: "Date",
+            dataType: "date",
+            required: true,
+          },
+          {
+            stateKey: "description[i]",
+            label: "Description",
+            dataType: "text",
+            required: false,
+          },
         ],
       },
-    };
+    }
   },
   async submit(shouldFail = false) {
-    await new Promise((resolve) => setTimeout(resolve, 1500));
-    if (shouldFail) throw new Error('Submission failed: Server timeout');
-    return { data: { id: Math.random().toString(36).substr(2, 9) } };
+    await new Promise((resolve) => setTimeout(resolve, 1500))
+    if (shouldFail) throw new Error("Submission failed: Server timeout")
+    return { data: { id: Math.random().toString(36).substr(2, 9) } }
   },
-};
+}
 
 const checkImageQuality = async () => {
-  await new Promise((resolve) => setTimeout(resolve, 500));
+  await new Promise((resolve) => setTimeout(resolve, 500))
   return {
     hasFourEdges: Math.random() > 0.2,
     blurVariance: Math.random() * 200,
     ocrConfidence: Math.random() * 100,
-  };
-};
+  }
+}
 
 // === HEADER WITH LOGO ===
 function UserHeader() {
-  const { user } = useContext(UserContext);
+  const { user } = useContext(UserContext)
   return (
     <div className="gradient-purple-dark text-white shadow-2xl">
       <div className="max-w-7xl mx-auto px-8 py-8 flex justify-between items-center">
@@ -132,91 +119,103 @@ function UserHeader() {
           </div>
         </div>
         <div className="text-right bg-white/10 rounded-2xl px-6 py-4 border border-white/15 shadow-lg">
-          <p className="font-bold text-readable-white">{user?.name || 'Demo User'}</p>
-          <p className="text-readable-white-light">{user?.email || 'demo@company.com'}</p>
+          <p className="font-bold text-readable-white">
+            {user?.name || "Demo User"}
+          </p>
+          <p className="text-readable-white-light">
+            {user?.email || "demo@company.com"}
+          </p>
         </div>
       </div>
     </div>
-  );
+  )
+}
+
+function SubmitSuccess({ onNavigate }) {
+  const { resetReceipt } = useContext(ReceiptContext)
+  return (
+    <div className="max-w-4xl mx-auto py-8 px-6 text-center">
+      <div className="modern-card animate-fade-in">
+        <div className="text-8xl mb-8 animate-float">🎉</div>
+        <h1 className="text-4xl font-bold text-readable mb-6">
+          Submission Complete!
+        </h1>
+        <p className="text-xl text-readable-light mb-10 font-medium">
+          Your document has been processed and submitted successfully.
+        </p>
+        <button
+          onClick={() => {
+            resetReceipt()
+            onNavigate("/upload")
+          }}
+          className="btn-modern hover:scale-105 transition-transform"
+        >
+          <span className="text-xl mr-2">📤</span>
+          <span className="font-bold">Submit Another Document</span>
+        </button>
+      </div>
+    </div>
+  )
 }
 
 // === MAIN APP ===
 export default function App() {
-  const [currentPage, setCurrentPage] = useState('/upload');
-  const [showExitConfirm, setShowExitConfirm] = useState(false);
-  const { resetReceipt } = useContext(ReceiptContext); // FIXED: moved hook out of handler
+  const [currentPage, setCurrentPage] = useState("/upload")
+  const [showExitConfirm, setShowExitConfirm] = useState(false)
 
-  const navigate = (path) => setCurrentPage(path);
-  const handleExit = () => setShowExitConfirm(true);
-  const confirmExit = () => window.close() || (window.location.href = 'about:blank');
+  const navigate = (path) => setCurrentPage(path)
+  const handleExit = () => setShowExitConfirm(true)
+  const confirmExit = () =>
+    window.close() || (window.location.href = "about:blank")
 
   const renderPage = () => {
-    if (currentPage === '/submit') {
-      return (
-        <div className="max-w-4xl mx-auto py-8 px-6 text-center">
-          <div className="modern-card animate-fade-in">
-            <div className="text-8xl mb-8 animate-float">🎉</div>
-            <h1 className="text-4xl font-bold text-readable mb-6">Submission Complete!</h1>
-            <p className="text-xl text-readable-light mb-10 font-medium">
-              Your document has been processed and submitted successfully.
-            </p>
-            <button
-              onClick={() => {
-                resetReceipt();
-                navigate('/upload');
-              }}
-              className="btn-modern hover:scale-105 transition-transform"
-            >
-              <span className="text-xl mr-2">📤</span>
-              <span className="font-bold">Submit Another Document</span>
-            </button>
-          </div>
-        </div>
-      );
+    if (currentPage === "/submit") {
+      return <SubmitSuccess onNavigate={navigate} />
     }
     return (
       <div className="max-w-4xl mx-auto py-8 px-6 text-center">
         <p className="text-readable-white">Other pages go here…</p>
       </div>
-    );
-  };
+    )
+  }
 
   return (
-    <UserProvider>
-      <ReceiptProvider>
-        <div className="min-h-screen gradient-purple">
-          <UserHeader />
-          <div className="py-10">{renderPage()}</div>
-          {showExitConfirm && (
-            <div className="fixed inset-0 bg-black/60 backdrop-blur-lg flex items-center justify-center z-50 p-4">
-              <div className="dialog-modern max-w-md w-full animate-fade-in">
-                <div className="p-8 border-l-4 border-red-400 bg-gradient-to-r from-red-50/95 to-pink-50/95">
-                  <div className="flex items-start">
-                    <div className="text-4xl mr-4">⚠️</div>
-                    <div className="flex-1">
-                      <h3 className="text-xl font-bold text-readable mb-3">Exit Application?</h3>
-                      <p className="text-readable-light font-medium">
-                        Any unsaved progress will be lost permanently.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                <div className="px-8 py-6 bg-gray-50/95 flex justify-end space-x-4 rounded-b-3xl">
-                  <button
-                    onClick={() => setShowExitConfirm(false)}
-                    className="btn-secondary hover:scale-105"
-                  >
-                    Stay
-                  </button>
-                  <button onClick={confirmExit} className="btn-danger hover:scale-105">
-                    Exit
-                  </button>
+    <div className="min-h-screen gradient-purple">
+      <UserHeader />
+      <div className="py-10">{renderPage()}</div>
+      {showExitConfirm && (
+        <div className="fixed inset-0 bg-black/60 backdrop-blur-lg flex items-center justify-center z-50 p-4">
+          <div className="dialog-modern max-w-md w-full animate-fade-in">
+            <div className="p-8 border-l-4 border-red-400 bg-gradient-to-r from-red-50/95 to-pink-50/95">
+              <div className="flex items-start">
+                <div className="text-4xl mr-4">⚠️</div>
+                <div className="flex-1">
+                  <h3 className="text-xl font-bold text-readable mb-3">
+                    Exit Application?
+                  </h3>
+                  <p className="text-readable-light font-medium">
+                    Any unsaved progress will be lost permanently.
+                  </p>
                 </div>
               </div>
             </div>
-          )}
+            <div className="px-8 py-6 bg-gray-50/95 flex justify-end space-x-4 rounded-b-3xl">
+              <button
+                onClick={() => setShowExitConfirm(false)}
+                className="btn-secondary hover:scale-105"
+              >
+                Stay
+              </button>
+              <button
+                onClick={confirmExit}
+                className="btn-danger hover:scale-105"
+              >
+                Exit
+              </button>
+            </div>
+          </div>
         </div>
-      </ReceiptProvider>
-    </UserProvider>
-  );
+      )}
+    </div>
+  )
 }

--- a/frontend/src/context/ReceiptContext.jsx
+++ b/frontend/src/context/ReceiptContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useEffect } from 'react'
+import React, { createContext, useState, useEffect } from "react"
 
 // Context for storing the current requisition state.  Fields map to the stateKey
 // values defined in backend/fieldMapping.json.  Attachments is an array of
@@ -6,18 +6,20 @@ import React, { createContext, useState, useEffect } from 'react'
 
 export const ReceiptContext = createContext(null)
 
+const initialReceipt = {
+  fields: {},
+  attachments: [],
+  signature: null,
+  contentTypeId: null,
+  contentTypeName: "",
+}
+
 export function ReceiptProvider({ children }) {
-  const [receipt, setReceipt] = useState({
-    fields: {},
-    attachments: [],
-    signature: null,
-    contentTypeId: null,
-    contentTypeName: '',
-  })
+  const [receipt, setReceipt] = useState(initialReceipt)
 
   const [contentTypes, setContentTypes] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem('contentTypes')
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("contentTypes")
       if (stored) {
         try {
           return JSON.parse(stored)
@@ -30,14 +32,22 @@ export function ReceiptProvider({ children }) {
   })
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('contentTypes', JSON.stringify(contentTypes))
+    if (typeof window !== "undefined") {
+      localStorage.setItem("contentTypes", JSON.stringify(contentTypes))
     }
   }, [contentTypes])
 
+  const resetReceipt = () => setReceipt(initialReceipt)
+
   return (
     <ReceiptContext.Provider
-      value={{ receipt, setReceipt, contentTypes, setContentTypes }}
+      value={{
+        receipt,
+        setReceipt,
+        contentTypes,
+        setContentTypes,
+        resetReceipt,
+      }}
     >
       {children}
     </ReceiptContext.Provider>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,13 +1,19 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
-import App from './App.jsx';
-import './index.css';
+import React from "react"
+import ReactDOM from "react-dom/client"
+import { BrowserRouter } from "react-router-dom"
+import App from "./App.jsx"
+import "./index.css"
+import { ReceiptProvider } from "./context/ReceiptContext.jsx"
+import { UserProvider } from "./context/UserContext.jsx"
 
-ReactDOM.createRoot(document.getElementById('root')).render(
+ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <UserProvider>
+        <ReceiptProvider>
+          <App />
+        </ReceiptProvider>
+      </UserProvider>
     </BrowserRouter>
   </React.StrictMode>,
-);
+)


### PR DESCRIPTION
## Summary
- wrap the app with global ReceiptProvider and UserProvider
- expose receipt reset in ReceiptContext
- move submission reset logic into a child component

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_689637b8cecc8332ae4e931055205d01