### PR TITLE
docs: add frontend env example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This repo only contains source code; dependencies are not vendored. To get up an
 
    ```bash
    cd frontend
+   # Copy `.env.example` to `.env` and update values as needed
    npm run dev
    ```
 
@@ -108,7 +109,7 @@ DEBUG_ENV=true node test-env.js
 
 ### API base URL
 
-The frontend looks for `VITE_API_BASE_URL` to know where the backend is running. When the variable is not set it defaults to `/api`.
+The frontend looks for `VITE_API_BASE_URL` to know where the backend is running. Copy `frontend/.env.example` to `frontend/.env` and set the value as needed. When the variable is not set it defaults to `/api`.
 
 ```bash
 # frontend/.env

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+# Rename this file to `.env` and update the variables as needed.
+# The frontend looks for VITE_API_BASE_URL to find the backend API.
+# VITE_API_BASE_URL=http://localhost:5000/api


### PR DESCRIPTION
## Summary
- add `frontend/.env.example` with template for `VITE_API_BASE_URL`
- document env setup for frontend and API base URL

## Testing
- `cd frontend && npm test -- --watchAll=false` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_689680a967a88332a4f91f5ba9d68a9b