### PR TITLE
feat: make field mappings dir configurable

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,16 @@
+# API Service
+
+The API service exposes endpoints for retrieving field mappings, uploading files, and submitting payloads.
+
+## Environment Variables
+
+- `FIELD_MAPPINGS_DIR`: path to the directory containing field mapping JSON files. Defaults to `../backend/fieldMappings` relative to this file. Set this if the mappings are stored elsewhere.
+
+## Development
+
+Install dependencies and run the test suite:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/api/app.py
+++ b/api/app.py
@@ -1,13 +1,15 @@
 import json
 from werkzeug.wrappers import Request
 import logging
+import os
 from pathlib import Path
 from urllib.parse import parse_qs
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-FIELD_MAPPINGS_DIR = Path(__file__).resolve().parent.parent / 'backend' / 'fieldMappings'
+DEFAULT_FIELD_MAPPINGS_DIR = Path(__file__).resolve().parent.parent / 'backend' / 'fieldMappings'
+FIELD_MAPPINGS_DIR = Path(os.environ.get('FIELD_MAPPINGS_DIR', DEFAULT_FIELD_MAPPINGS_DIR))
 CONTENT_TYPE_MAP = {
   'vendor-invoice': 'vendor-invoice.json',
   'tcfv-card': 'tcfv-card.json',

--- a/api/tests/test_api_endpoints.py
+++ b/api/tests/test_api_endpoints.py
@@ -5,6 +5,12 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+os.environ.setdefault(
+  'FIELD_MAPPINGS_DIR',
+  os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', '..', 'backend', 'fieldMappings')
+  )
+)
 from api.app import app
 
 


### PR DESCRIPTION
## Summary
- allow configuring field mapping location via FIELD_MAPPINGS_DIR
- document FIELD_MAPPINGS_DIR usage
- set FIELD_MAPPINGS_DIR in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6896891438c48332adc5f7aaa94c3d09