### PR TITLE
feat: enforce CORS allowed origins

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,5 +18,5 @@ LIST_ID=
 # Port number for the backend API (optional).  Defaults to 5000.
 #PORT=5000
 
-# Comma-separated origins allowed to access the backend
+# Required: comma-separated origins allowed to access the backend (e.g. http://localhost:3000)
 ALLOWED_ORIGINS=

--- a/backend/server.js
+++ b/backend/server.js
@@ -87,8 +87,21 @@ const upload = multer({
   },
 })
 
-const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',')
-app.use(cors({ origin: allowedOrigins }))
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(',').map((o) => o.trim()).filter(Boolean)
+  : []
+
+if (!allowedOrigins.length)
+  console.warn('No ALLOWED_ORIGINS specified; requests from unknown origins will be blocked')
+
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (!origin || allowedOrigins.includes(origin)) callback(null, true)
+      else callback(new Error('Not allowed by CORS'))
+    },
+  }),
+)
 app.use(express.json({ limit: '50mb' }))
 
 /**


### PR DESCRIPTION
## Summary
- parse `ALLOWED_ORIGINS` env var and verify requests against it
- document required `ALLOWED_ORIGINS` in backend environment template

## Testing
- `cd backend && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_b_68969758603c8332a389aceecc1393ce