### PR TITLE
chore: pin Werkzeug to 3.0.1

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,1 +1,1 @@
-Werkzeug>=3.0.0
+Werkzeug==3.0.1


### PR DESCRIPTION
## Summary
- pin Werkzeug to 3.0.1 in API requirements

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Werkzeug==3.0.1)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68969d072ca48332b199cb9a25061138