### PR TITLE
feat: add JWT auth middleware

### DIFF
--- a/backend/__tests__/server.test.js
+++ b/backend/__tests__/server.test.js
@@ -1,4 +1,5 @@
 const request = require('supertest')
+const jwt = require('jsonwebtoken')
 jest.mock('../sharepointClient', () => ({
   createItemWithContentType: jest.fn(() => Promise.resolve({ id: 'item' })),
   listActiveUsers: jest.fn(() => Promise.resolve([])),
@@ -7,6 +8,8 @@ jest.mock('../sharepointClient', () => ({
 const { createItemWithContentType } = require('../sharepointClient')
 process.env.AZURE_DOC_INTELLIGENCE_ENDPOINT = 'https://example.com'
 process.env.AZURE_DOC_INTELLIGENCE_KEY = 'test-key'
+process.env.JWT_SECRET = 'test-secret'
+const token = jwt.sign({ sub: 'tester' }, process.env.JWT_SECRET)
 const app = require('../server')
 const fieldMapping = require('../fieldMapping.json')
 const personalCardMapping = require('../fieldMappings/personal-card.json')
@@ -35,13 +38,21 @@ describe('server routes', () => {
   })
 
   it('rejects upload without file', async () => {
-    const res = await request(app).post('/api/upload')
+    const res = await request(app)
+      .post('/api/upload')
+      .set('Authorization', `Bearer ${token}`)
     expect(res.status).toBe(400)
+  })
+
+  it('requires auth for upload', async () => {
+    const res = await request(app).post('/api/upload')
+    expect(res.status).toBe(401)
   })
 
   it('submits stub data', async () => {
     const res = await request(app)
       .post('/api/submit')
+      .set('Authorization', `Bearer ${token}`)
       .send({
         fields: {},
         attachments: [],
@@ -52,6 +63,13 @@ describe('server routes', () => {
     expect(res.body.success).toBe(true)
   })
 
+  it('requires auth for submit', async () => {
+    const res = await request(app)
+      .post('/api/submit')
+      .send({})
+    expect(res.status).toBe(401)
+  })
+
   it('passes attachment content to sharepoint client', async () => {
     const attachment = {
       name: 'file.txt',
@@ -60,6 +78,7 @@ describe('server routes', () => {
     }
     const res = await request(app)
       .post('/api/submit')
+      .set('Authorization', `Bearer ${token}`)
       .send({
         fields: {},
         attachments: [attachment],
@@ -75,14 +94,28 @@ describe('server routes', () => {
   })
 
   it('lists users', async () => {
-    const res = await request(app).get('/api/users')
+    const res = await request(app)
+      .get('/api/users')
+      .set('Authorization', `Bearer ${token}`)
     expect(res.status).toBe(200)
     expect(Array.isArray(res.body)).toBe(true)
   })
 
+  it('requires auth for users', async () => {
+    const res = await request(app).get('/api/users')
+    expect(res.status).toBe(401)
+  })
+
   it('lists content types', async () => {
-    const res = await request(app).get('/api/content-types')
+    const res = await request(app)
+      .get('/api/content-types')
+      .set('Authorization', `Bearer ${token}`)
     expect(res.status).toBe(200)
     expect(Array.isArray(res.body)).toBe(true)
+  })
+
+  it('requires auth for content types', async () => {
+    const res = await request(app).get('/api/content-types')
+    expect(res.status).toBe(401)
   })
 })

--- a/backend/__tests__/upload.test.js
+++ b/backend/__tests__/upload.test.js
@@ -1,4 +1,5 @@
 const request = require('supertest')
+const jwt = require('jsonwebtoken')
 
 jest.mock('../docIntelligenceClient', () => ({
   analyzeDocument: jest.fn(() =>
@@ -34,12 +35,15 @@ jest.mock('../docIntelligenceClient', () => ({
 
 process.env.AZURE_DOC_INTELLIGENCE_ENDPOINT = 'https://example.com'
 process.env.AZURE_DOC_INTELLIGENCE_KEY = 'test-key'
+process.env.JWT_SECRET = 'test-secret'
+const token = jwt.sign({ sub: 'tester' }, process.env.JWT_SECRET)
 const app = require('../server')
 
 describe('upload multiple files', () => {
   it('applies field mapping and transformations', async () => {
     const res = await request(app)
       .post('/api/upload')
+      .set('Authorization', `Bearer ${token}`)
       .field(
         'selectedContentType',
         JSON.stringify({ Name: 'Purchase Requisition - Vendor Invoice' }),
@@ -66,6 +70,7 @@ describe('upload multiple files', () => {
   it('returns 400 for invalid selectedContentType payload', async () => {
     const res = await request(app)
       .post('/api/upload')
+      .set('Authorization', `Bearer ${token}`)
       .field('selectedContentType', '{ invalid')
       .attach('files', Buffer.from('one'), 'one.png')
     expect(res.status).toBe(400)
@@ -73,12 +78,19 @@ describe('upload multiple files', () => {
   })
 
   it('rejects when too many files are uploaded', async () => {
-    const req = request(app).post('/api/upload')
+    const req = request(app)
+      .post('/api/upload')
+      .set('Authorization', `Bearer ${token}`)
     for (let i = 0; i < 6; i++) {
       req.attach('files', Buffer.from(String(i)), `f${i}.png`)
     }
     const res = await req
     expect(res.status).toBe(400)
     expect(res.body.error).toMatch(/too many files/i)
+  })
+
+  it('requires auth', async () => {
+    const res = await request(app).post('/api/upload')
+    expect(res.status).toBe(401)
   })
 })

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "isomorphic-fetch": "^3.0.0",
+    "jsonwebtoken": "^9.0.2",
     "multer": "2.0.2",
     "node-fetch": "^2.6.12"
   },


### PR DESCRIPTION
## Summary
- add JWT auth middleware
- protect upload, submit, users, and content-type routes
- test authorized and unauthorized access

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6896a2b93bf48332b3a33df72beba0c9