### PR TITLE
chore: pin tus-js-client version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
     "dotenv": "^17.2.1",
-    "tus-js-client": "latest"
+    "tus-js-client": "3.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- pin `tus-js-client` dependency to 3.0.0

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tus-js-client/-/tus-js-client-3.0.0.tgz)*
- `npm test -- --watchAll=false` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_689698a4e6b08332818f6b4b1addc44a