### PR TITLE
Automated critical fixes: scan 2025-08-09

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -23,6 +23,7 @@ USER_LIST = [
 ]
 
 ALLOWED_MIMETYPES = {'application/pdf'}
+MAX_UPLOAD_SIZE = 5 * 1024 * 1024  # 5 MB limit
 
 
 def load_field_mapping(content_type: str | None):
@@ -79,6 +80,10 @@ def app(environ, start_response):
         if not (mt.startswith('image/') or mt in ALLOWED_MIMETYPES):
           start_response('415 Unsupported Media Type', [('Content-Type', 'application/json')])
           return [json.dumps({'error': f"Unsupported file type '{mt}'"}).encode()]
+        size = getattr(f, 'content_length', 0) or 0
+        if size > MAX_UPLOAD_SIZE:
+          start_response('413 Payload Too Large', [('Content-Type', 'application/json')])
+          return [json.dumps({'error': 'File too large'}).encode()]
     data = [{'success': True, 'data': {'filename': f.filename}} for f in files if f.filename]
     start_response('200 OK', [('Content-Type', 'application/json')])
     return [json.dumps(data).encode()]

--- a/backend/server.js
+++ b/backend/server.js
@@ -31,7 +31,10 @@ function authMiddleware(req, res, next) {
   }
   try {
     const token = header.split(' ')[1]
-    req.user = jwt.verify(token, process.env.JWT_SECRET)
+    // Restrict accepted algorithms to avoid algorithm confusion attacks
+    req.user = jwt.verify(token, process.env.JWT_SECRET, {
+      algorithms: ['HS256'],
+    })
     next()
   } catch (err) {
     res.status(401).json({ error: 'Unauthorized' })


### PR DESCRIPTION
## Summary
| Severity | Count |
|----------|-------|
| Critical | 0 |
| High | 2 |
| Medium | 0 |
| Low | 0 |

**Top risk themes:** weak JWT verification; missing upload limits

## Changes
- `backend/server.js`: restrict JWT verification to HS256 to prevent algorithm confusion.
- `api/app.py`: cap upload size at 5 MB and reject oversized files to reduce DoS risk.

## Remaining issues
- Frontend Jest tests fail to parse `import.meta` syntax; update test configuration.
- `npm audit` and `pip-audit` were blocked (403); rerun with registry access to assess dependency vulnerabilities.

## Testing
- `npm test -- --watchAll=false` in `backend/`
- `pytest -q` in `api/`
- `npm test -- --watchAll=false` in `frontend/` *(fails: cannot use `import.meta` outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_68977841ab588332809754f0d9f7dae8