### PR TITLE
feat: add msal config and token fallback

### DIFF
--- a/frontend/src/context/UserContext.jsx
+++ b/frontend/src/context/UserContext.jsx
@@ -1,4 +1,5 @@
 import React, { createContext, useEffect, useState } from 'react'
+import { msalConfig, getToken } from '../msalConfig'
 
 export const UserContext = createContext({ user: null, setUser: () => {} })
 
@@ -10,20 +11,12 @@ export function UserProvider({ children }) {
     async function load() {
       try {
         const { PublicClientApplication } = await import('@azure/msal-browser')
-        const pca = new PublicClientApplication({
-          auth: {
-            clientId: import.meta.env.VITE_AZURE_CLIENT_ID,
-            authority: `https://login.microsoftonline.com/${import.meta.env.VITE_AZURE_TENANT_ID}`
-          }
-        })
+        const pca = new PublicClientApplication(msalConfig)
         await pca.initialize()
         const account = await pca
           .ssoSilent({ scopes: ['User.Read'] })
           .then(r => r.account)
-        const token = await pca.acquireTokenSilent({
-          scopes: ['User.Read'],
-          account
-        })
+        const token = await getToken(pca, account, { scopes: ['User.Read'] })
         if (active)
           setUser({
             id: account?.homeAccountId || null,

--- a/frontend/src/msalConfig.ts
+++ b/frontend/src/msalConfig.ts
@@ -1,0 +1,24 @@
+export const msalConfig = {
+  auth: {
+    clientId: process.env.NEXT_PUBLIC_MSAL_CLIENT_ID,
+    authority: `https://login.microsoftonline.com/${process.env.NEXT_PUBLIC_TENANT_ID}`,
+    redirectUri: process.env.NEXT_PUBLIC_REDIRECT_URI || window.location.origin,
+    postLogoutRedirectUri: window.location.origin
+  },
+  cache: {
+    cacheLocation: 'localStorage',
+    storeAuthStateInCookie: true
+  },
+  system: {
+    allowRedirectInIframe: false,
+    iframeHashTimeout: 7000
+  }
+}
+
+export async function getToken(instance, account, request) {
+  try {
+    return await instance.acquireTokenSilent({ ...request, account })
+  } catch (e) {
+    return instance.acquireTokenRedirect(request)
+  }
+}


### PR DESCRIPTION
## Summary
- centralize MSAL configuration with localStorage caching and iframe-safe options
- add graceful token acquisition fallback for interactive flows
- refactor user context to use shared MSAL config and helper

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_68978330284083329720b27b6ca6400a