### PR TITLE
test: configure frontend jest for import.meta

### DIFF
--- a/frontend/__mocks__/fileMock.js
+++ b/frontend/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub'

--- a/frontend/__mocks__/styleMock.js
+++ b/frontend/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,3 +1,7 @@
 module.exports = {
-  presets: ['@babel/preset-env', '@babel/preset-react']
+  presets: [
+    '@babel/preset-env',
+    ['@babel/preset-react', { runtime: 'automatic' }]
+  ],
+  plugins: ['./babelTransformImportMeta']
 }

--- a/frontend/babelTransformImportMeta.js
+++ b/frontend/babelTransformImportMeta.js
@@ -1,0 +1,11 @@
+module.exports = function () {
+  return {
+    visitor: {
+      MetaProperty(path) {
+        if (path.node.meta.name === 'import' && path.node.property.name === 'meta') {
+          path.replaceWithSourceString('({ env: process.env, url: "http://localhost/" })')
+        }
+      },
+    },
+  }
+}

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,6 +1,10 @@
 module.exports = {
-  testEnvironment: 'node',
+  testEnvironment: 'jsdom',
   transform: {
     '^.+\\.jsx?$': 'babel-jest'
+  },
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': '<rootDir>/__mocks__/styleMock.js',
+    '\\.(jpg|jpeg|png|gif|webp|svg)$': '<rootDir>/__mocks__/fileMock.js'
   }
 }


### PR DESCRIPTION
## Summary
- add custom Babel plugin to stub `import.meta` during tests
- configure Jest to use jsdom and mock static assets

## Testing
- `npm test -- --watchAll=false` *(frontend: fails — Test environment jest-environment-jsdom cannot be found)*
- `npm test -- --watchAll=false` *(backend)*

------
https://chatgpt.com/codex/tasks/task_b_68978c619ab08332991c52ace31fb6e4