### PR TITLE
UI smoke test with Microsoft 365 login using CI secrets

### DIFF
--- a/.github/workflows/ui-smoke.yml
+++ b/.github/workflows/ui-smoke.yml
@@ -1,0 +1,30 @@
+name: UI smoke
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * *'
+
+env:
+  E2E_BASE_URL: ${{ secrets.E2E_BASE_URL }}
+  E2E_USERNAME: ${{ secrets.E2E_USERNAME }}
+  E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm run ui:login
+      - run: npm run ui:test
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ui-artifacts
+          path: ui-artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ node_modules/
 .vscode/
 *.log
 
+
+# UI testing
+.auth/
+ui-artifacts/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,14 @@
 {
+  "scripts": {
+    "test": "npm test --prefix frontend",
+    "ui:test": "playwright test",
+    "ui:login": "playwright test tests/login.setup.ts"
+  },
   "dependencies": {
     "dotenv": "^17.2.1",
     "tus-js-client": "3.0.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.45.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+
+const date = new Date().toISOString().split('T')[0]
+const artifactsDir = path.join('ui-artifacts', date)
+fs.mkdirSync(artifactsDir, { recursive: true })
+
+export default defineConfig({
+  testDir: './tests',
+  globalSetup: require.resolve('./tests/global.setup'),
+  use: {
+    baseURL: process.env.E2E_BASE_URL,
+    storageState: '.auth/state.json'
+  },
+  projects: [
+    {
+      name: 'desktop',
+      use: {
+        viewport: { width: 1280, height: 800 },
+        recordHar: { path: path.join(artifactsDir, 'desktop.har') }
+      }
+    },
+    {
+      name: 'tablet',
+      use: {
+        viewport: { width: 768, height: 1024 },
+        recordHar: { path: path.join(artifactsDir, 'tablet.har') }
+      }
+    },
+    {
+      name: 'mobile',
+      use: {
+        viewport: { width: 390, height: 844 },
+        recordHar: { path: path.join(artifactsDir, 'mobile.har') }
+      }
+    }
+  ]
+})

--- a/tests/crawler.spec.ts
+++ b/tests/crawler.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+
+const startUrl = process.env.E2E_BASE_URL || ''
+const baseOrigin = startUrl ? new URL(startUrl).origin : ''
+const date = new Date().toISOString().split('T')[0]
+const artifactRoot = path.join('ui-artifacts', date)
+fs.mkdirSync(artifactRoot, { recursive: true })
+
+test('authenticated crawl', async ({ page }, testInfo) => {
+  const visited = new Set<string>()
+  const queue: { url: string; depth: number }[] = [{ url: startUrl, depth: 0 }]
+
+  while (queue.length) {
+    const { url, depth } = queue.shift()!
+    if (visited.has(url) || depth > 2) continue
+    visited.add(url)
+
+    const consoleMessages: string[] = []
+    const badResponses: string[] = []
+
+    const consoleListener = (msg: any) => {
+      if (msg.type() === 'error' || (msg.type() === 'warning' && /hydration/i.test(msg.text()))) {
+        consoleMessages.push(msg.text())
+      }
+    }
+    const responseListener = (resp: any) => {
+      if (resp.status() >= 400) badResponses.push(`${resp.url()} ${resp.status()}`)
+    }
+    page.on('console', consoleListener)
+    page.on('response', responseListener)
+
+    const response = await page.goto(url)
+    expect(response?.status(), `status for ${url}`).toBeLessThan(400)
+    await page.waitForLoadState('networkidle')
+
+    expect(badResponses, `HTTP errors for ${url}: ${badResponses.join(', ')}`).toEqual([])
+    expect(consoleMessages, `Console errors for ${url}: ${consoleMessages.join(', ')}`).toEqual([])
+
+    await expect(page.locator('header')).toBeVisible()
+    await expect(page.locator('main')).toBeVisible()
+    await expect(page.locator('footer')).toBeVisible()
+    const headingCount = await page.locator('h1, h2').count()
+    expect(headingCount, `no h1/h2 at ${url}`).toBeGreaterThan(0)
+
+    const resources = await page.evaluate(() => {
+      const urls: string[] = []
+      document.querySelectorAll('img[src]').forEach(e => urls.push((e as HTMLImageElement).src))
+      document.querySelectorAll('link[rel="stylesheet"]').forEach(e => urls.push((e as HTMLLinkElement).href))
+      document.querySelectorAll('script[src]').forEach(e => urls.push((e as HTMLScriptElement).src))
+      return urls
+    })
+    for (const resUrl of resources) {
+      const absolute = new URL(resUrl, baseOrigin).href
+      const res = await page.request.get(absolute)
+      expect(res.status(), `${absolute} failed`).toBe(200)
+    }
+
+    const safeName = url.replace(baseOrigin, '').replace(/[^a-z0-9]+/gi, '_') || 'home'
+    await page.screenshot({ path: path.join(artifactRoot, `${safeName}-${testInfo.project.name}.png`), fullPage: true })
+
+    page.off('console', consoleListener)
+    page.off('response', responseListener)
+
+    if (depth < 2) {
+      const links = await page.$$eval('a[href]', els => els.map(e => (e as HTMLAnchorElement).href))
+      for (const link of links) {
+        const absolute = new URL(link, baseOrigin).href
+        if (absolute.startsWith(baseOrigin) && !visited.has(absolute)) {
+          queue.push({ url: absolute, depth: depth + 1 })
+        }
+      }
+    }
+  }
+})

--- a/tests/global.setup.ts
+++ b/tests/global.setup.ts
@@ -1,0 +1,20 @@
+import { chromium } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+import { loginM365 } from './helpers/login-m365'
+
+const storagePath = path.join('.auth', 'state.json')
+
+export default async function globalSetup() {
+  const maxAge = 24 * 60 * 60 * 1000
+  if (fs.existsSync(storagePath)) {
+    const age = Date.now() - fs.statSync(storagePath).mtimeMs
+    if (age < maxAge) return
+  }
+
+  const browser = await chromium.launch()
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  await loginM365(page)
+  await browser.close()
+}

--- a/tests/helpers/login-m365.ts
+++ b/tests/helpers/login-m365.ts
@@ -1,0 +1,34 @@
+import { Page } from '@playwright/test'
+import fs from 'fs'
+import path from 'path'
+
+const storagePath = path.join('.auth', 'state.json')
+
+export async function loginM365(page: Page) {
+  const baseUrl = process.env.E2E_BASE_URL || ''
+  const username = process.env.E2E_USERNAME || ''
+  const password = process.env.E2E_PASSWORD || ''
+  const stay = process.env.E2E_STAY_SIGNED_IN === 'yes'
+
+  await page.goto(baseUrl)
+  await page.getByRole('button', { name: /sign in/i }).click()
+
+  await page.fill('input[name="loginfmt"]', username)
+  await page.getByRole('button', { name: /next/i }).click()
+
+  await page.fill('input[name="passwd"]', password)
+  await page.getByRole('button', { name: /sign in/i }).click()
+
+  try {
+    await page.getByRole('button', { name: stay ? /yes/i : /no/i }).click({ timeout: 5000 })
+  } catch {}
+
+  try {
+    await page.getByRole('button', { name: /accept/i }).click({ timeout: 5000 })
+  } catch {}
+
+  await page.waitForURL('**/dashboard')
+
+  fs.mkdirSync(path.dirname(storagePath), { recursive: true })
+  await page.context().storageState({ path: storagePath })
+}

--- a/tests/login.setup.ts
+++ b/tests/login.setup.ts
@@ -1,0 +1,6 @@
+import { test as setup } from '@playwright/test'
+import { loginM365 } from './helpers/login-m365'
+
+setup('login', async ({ page }) => {
+  await loginM365(page)
+})


### PR DESCRIPTION
## Summary
- set up Playwright config with auth storage and multiple viewports
- add Microsoft 365 login helper and UI crawler test
- run crawler in CI with secrets-provided credentials

## Testing
- `npm test -- --watchAll=false` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `E2E_BASE_URL=https://example.com E2E_USERNAME=test E2E_PASSWORD=test npm run ui:test` *(fails: playwright: not found)*
- `E2E_BASE_URL=https://example.com E2E_USERNAME=test E2E_PASSWORD=test npm run ui:login` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68978f7326d88332a4a4bcf33c2ab0ec