### PR TITLE
feat: add placeholder for processed files

### DIFF
--- a/frontend/src/pages/UploadPage.jsx
+++ b/frontend/src/pages/UploadPage.jsx
@@ -151,6 +151,14 @@ export default function UploadPage() {
         <FileUpload key={inputKey} onFileSelected={handleFileUpload} />
       </section>
 
+      {readyAttachments.length === 0 && (
+        <section className="modern-card animate-fade-in mb-8 text-center py-12">
+          <p className="text-readable-light">
+            Uploaded files ready for processing will appear here.
+          </p>
+        </section>
+      )}
+
       {readyAttachments.length > 0 && (
         <section className="modern-card animate-fade-in mb-8">
           <div className="flex items-center justify-between mb-4">


### PR DESCRIPTION
## Summary
- show a modern-card placeholder explaining where processed files will appear when none are ready

## Testing
- `npm test -- --watchAll=false` *(fails: jest-environment-jsdom cannot be found; attempted install but received 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6897935095fc8332a2aac55f0a48def5