### PR TITLE
feat: add skeleton loader and retry to review page

### DIFF
--- a/frontend/src/components/MappingSkeleton.jsx
+++ b/frontend/src/components/MappingSkeleton.jsx
@@ -1,0 +1,14 @@
+import React from "react"
+
+export default function MappingSkeleton({ count = 3 }) {
+  return (
+    <div className="modern-card animate-fade-in">
+      {Array.from({ length: count }).map((_, idx) => (
+        <div key={idx} className="mb-5">
+          <div className="h-4 bg-white/20 rounded w-1/3 mb-2 animate-pulse" />
+          <div className="h-10 bg-white/20 rounded animate-pulse" />
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add MappingSkeleton component to display placeholders while field mappings load
- allow retrying failed field mapping requests
- disable form inputs until field mappings finish loading

## Testing
- `npm test -- --watchAll=false` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_b_6897950dd64c8332aa94c0efa395c4e8