### PR TITLE
feat: add msal config and jwt middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,11 +4,17 @@
 # Enable built-in demo with mock auth and OCR
 DEMO_MODE=true
 AUTH_PROVIDER=msal
+VITE_DEMO_MODE=true
+VITE_AUTH_PROVIDER=msal
 # Optional Azure placeholders when exploring demo
 TENANT_ID=
 CLIENT_ID=
 AZURE_DOC_INTELLIGENCE_ENDPOINT=
 AZURE_DOC_INTELLIGENCE_KEY=
+VITE_MSAL_CLIENT_ID=
+VITE_MSAL_TENANT_ID=
+VITE_MSAL_REDIRECT_URI=http://localhost:5173
+VITE_API_BASE_URL=/api
 
 # --- Local Production ---
 # Real authentication using local provider
@@ -16,6 +22,9 @@ DEMO_MODE=false
 AUTH_PROVIDER=local
 JWT_SECRET=REQUIRED
 CORS_ORIGIN=http://localhost:5173
+VITE_DEMO_MODE=false
+VITE_AUTH_PROVIDER=local
+VITE_API_BASE_URL=http://localhost:5000/api
 
 # --- MSAL Production ---
 # Use Azure AD/MSAL for auth
@@ -23,5 +32,11 @@ DEMO_MODE=false
 AUTH_PROVIDER=msal
 TENANT_ID=your-tenant-id
 CLIENT_ID=your-client-id
+VITE_DEMO_MODE=false
+VITE_AUTH_PROVIDER=msal
+VITE_MSAL_CLIENT_ID=your-client-id
+VITE_MSAL_TENANT_ID=your-tenant-id
+VITE_MSAL_REDIRECT_URI=https://your-domain.example
+VITE_API_BASE_URL=/api
 AZURE_DOC_INTELLIGENCE_ENDPOINT=https://<resource>.cognitiveservices.azure.com
 AZURE_DOC_INTELLIGENCE_KEY=

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ VITE_API_BASE_URL=http://localhost:5000/api
 ### Authentication
 
 Redirect URIs for the Azure AD app must include both your deployed origin (e.g. Vercel) and `http://localhost` for local development. Authentication uses the Authorization Code flow with PKCE via MSAL; no implicit grant is required.
+The frontend reads `VITE_MSAL_CLIENT_ID`, `VITE_MSAL_TENANT_ID` and `VITE_MSAL_REDIRECT_URI` to configure the MSAL client.
 
 ## Running in production
 

--- a/backend/middleware/authJwt.js
+++ b/backend/middleware/authJwt.js
@@ -1,0 +1,40 @@
+const jwt = require('jsonwebtoken')
+const fetch = require('node-fetch')
+
+let jwks
+async function getKey(kid) {
+  if (!jwks) {
+    const res = await fetch(`https://login.microsoftonline.com/${process.env.TENANT_ID}/discovery/v2.0/keys`)
+    jwks = await res.json()
+  }
+  const key = jwks.keys.find(k => k.kid === kid)
+  if (!key) throw new Error('JWKS key not found')
+  const pem = `-----BEGIN CERTIFICATE-----\n${key.x5c[0]}\n-----END CERTIFICATE-----`
+  return pem
+}
+
+async function verify(token) {
+  const header = jwt.decode(token, { complete: true })?.header
+  if (!header) throw new Error('Invalid token')
+  const signingKey = await getKey(header.kid)
+  return jwt.verify(token, signingKey, {
+    algorithms: ['RS256'],
+    audience: `api://${process.env.CLIENT_ID}`,
+    issuer: `https://login.microsoftonline.com/${process.env.TENANT_ID}/v2.0`,
+  })
+}
+
+function requireJwtAuth(req, res, next) {
+  const auth = req.headers.authorization
+  if (!auth || !auth.startsWith('Bearer '))
+    return res.status(401).json({ error: 'Unauthorized' })
+  const token = auth.slice(7)
+  verify(token)
+    .then(payload => {
+      req.auth = payload
+      next()
+    })
+    .catch(() => res.status(401).json({ error: 'Unauthorized' }))
+}
+
+module.exports = { requireJwtAuth }

--- a/backend/server.js
+++ b/backend/server.js
@@ -11,6 +11,7 @@ const authProvider =
   config.AUTH_PROVIDER === 'local'
     ? new LocalAuthProvider(config)
     : new MsalAuthProvider(config)
+const { requireJwtAuth } = require('./middleware/authJwt')
 const { analyzeDocument } = require('./docIntelligenceClient')
 const { getDocumentModel } = require('./getDocumentModel')
 const {
@@ -111,6 +112,9 @@ const staticDir = path.resolve(__dirname, '../frontend/dist')
 app.use(express.static(staticDir))
 app.get('/health', (req, res) => res.json({ status: 'ok' }))
 app.use('/auth', authProvider.router)
+
+if (!config.DEMO_MODE && config.AUTH_PROVIDER === 'msal')
+  app.use('/api', requireJwtAuth)
 
 /**
  * GET /api/fields

--- a/backend/src/auth/MsalAuthProvider.js
+++ b/backend/src/auth/MsalAuthProvider.js
@@ -12,22 +12,22 @@ class MsalAuthProvider extends AuthProvider {
   }
 
   getUserFromRequest(req) {
-    if (this.config.DEMO_MODE) {
+    if (this.config.DEMO_MODE)
       return { id: 'demo', name: 'Demo User', email: 'demo@example.com' }
-    }
-    const header = req.headers.authorization
-    if (!header || !header.startsWith('Bearer ')) return null
-    const token = header.slice(7)
-    try {
-      // In production verify token signature against Azure AD JWKS
-      const decoded = jwt.decode(token)
-      return {
-        id: decoded?.oid || null,
-        name: decoded?.name || null,
-        email: decoded?.preferred_username || null
+    let decoded = req.auth
+    if (!decoded) {
+      const header = req.headers.authorization
+      if (!header || !header.startsWith('Bearer ')) return null
+      try {
+        decoded = jwt.decode(header.slice(7))
+      } catch {
+        return null
       }
-    } catch {
-      return null
+    }
+    return {
+      id: decoded?.oid || null,
+      name: decoded?.name || null,
+      email: decoded?.preferred_username || null
     }
   }
 }

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,9 @@
 # Rename this file to `.env` and update the variables as needed.
 # The frontend looks for VITE_API_BASE_URL to find the backend API.
-# VITE_API_BASE_URL=http://localhost:5000/api
+VITE_API_BASE_URL=/api
 VITE_AUTH_PROVIDER=msal
 VITE_DEMO_MODE=true
+# MSAL configuration for production
+VITE_MSAL_CLIENT_ID=
+VITE_MSAL_TENANT_ID=
+VITE_MSAL_REDIRECT_URI=http://localhost:5173

--- a/frontend/src/auth/msalConfig.ts
+++ b/frontend/src/auth/msalConfig.ts
@@ -1,9 +1,15 @@
 export const msalConfig = {
   auth: {
-    clientId: process.env.NEXT_PUBLIC_MSAL_CLIENT_ID!,
-    authority: `https://login.microsoftonline.com/${process.env.NEXT_PUBLIC_TENANT_ID}`,
-    redirectUri: typeof window === 'undefined' ? undefined : window.location.origin,
-    postLogoutRedirectUri: typeof window === 'undefined' ? undefined : window.location.origin,
+    clientId: import.meta.env.VITE_MSAL_CLIENT_ID,
+    authority: `https://login.microsoftonline.com/${import.meta.env.VITE_MSAL_TENANT_ID}`,
+    redirectUri:
+      typeof window === 'undefined'
+        ? undefined
+        : import.meta.env.VITE_MSAL_REDIRECT_URI || window.location.origin,
+    postLogoutRedirectUri:
+      typeof window === 'undefined'
+        ? undefined
+        : import.meta.env.VITE_MSAL_REDIRECT_URI || window.location.origin,
   },
   cache: { cacheLocation: 'localStorage', storeAuthStateInCookie: true },
   system: { allowRedirectInIframe: false, iframeHashTimeout: 7000 }


### PR DESCRIPTION
## Summary
- add JWKS-based JWT auth middleware
- wire middleware into Express when using MSAL
- switch frontend MSAL config to Vite env vars and expand env examples

## Testing
- `npm test -- --watchAll=false` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `NODE_ENV=development DEMO_MODE=true npm test --prefix backend` *(fails: requires auth for upload/submit/users/content types)*

------
https://chatgpt.com/codex/tasks/task_b_68979c084a50833288c5caf225514da0