### PR TITLE
chore: point frontend to external backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ AZURE_DOC_INTELLIGENCE_KEY=
 VITE_MSAL_CLIENT_ID=
 VITE_MSAL_TENANT_ID=
 VITE_MSAL_REDIRECT_URI=http://localhost:5173
-VITE_API_BASE_URL=/api
+VITE_API_BASE_URL=https://backend.example.com/api
 
 # --- Local Production ---
 # Real authentication using local provider
@@ -37,6 +37,6 @@ VITE_AUTH_PROVIDER=msal
 VITE_MSAL_CLIENT_ID=your-client-id
 VITE_MSAL_TENANT_ID=your-tenant-id
 VITE_MSAL_REDIRECT_URI=https://your-domain.example
-VITE_API_BASE_URL=/api
+VITE_API_BASE_URL=https://backend.example.com/api
 AZURE_DOC_INTELLIGENCE_ENDPOINT=https://<resource>.cognitiveservices.azure.com
 AZURE_DOC_INTELLIGENCE_KEY=

--- a/README.md
+++ b/README.md
@@ -127,11 +127,11 @@ DEBUG_ENV=true node test-env.js
 
 ### API base URL
 
-The frontend looks for `VITE_API_BASE_URL` to know where the backend is running. Copy `frontend/.env.example` to `frontend/.env` and set the value as needed. When the variable is not set it defaults to `/api`.
+The frontend looks for `VITE_API_BASE_URL` to know where the backend is running. Copy `frontend/.env.example` to `frontend/.env` and set the value as needed. When the variable is not set it defaults to `/api`, but in production it should point to the dedicated backend service.
 
 ```bash
 # frontend/.env
-VITE_API_BASE_URL=http://localhost:5000/api
+VITE_API_BASE_URL=https://backend.example.com/api
 ```
 
 ### Authentication

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,8 @@
 {
   "rewrites": [
-    { "source": "/api/(.*)", "destination": "/api/$1" },
     { "source": "/(.*)", "destination": "/" }
-  ]
+  ],
+  "env": {
+    "VITE_API_BASE_URL": "https://backend.example.com/api"
+  }
 }


### PR DESCRIPTION
## Summary
- remove local API rewrite and configure Vercel to use an external backend URL
- document backend URL usage and update environment example

## Testing
- `npm test -- --watchAll=false` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_b_6898f270fb9c8332a8a1681341ee8355