### PR TITLE
feat: add jsdom test environment dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "@testing-library/user-event": "^14.4.3",
     "babel-jest": "^29.7.0",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "@babel/preset-env": "^7.24.0",
     "@babel/preset-react": "^7.22.15"
   }


### PR DESCRIPTION
## Summary
- add jest-environment-jsdom dev dependency for frontend tests

## Testing
- `npm install` *(fails: 403 Forbidden to jest-environment-jsdom)*
- `npm test -- --watchAll=false` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_b_6898f9ab03b083328bfb2141e7580c38