### PR TITLE
fix: document optional proxy env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,8 @@ VITE_MSAL_REDIRECT_URI=https://your-domain.example
 VITE_API_BASE_URL=https://backend.example.com/api
 AZURE_DOC_INTELLIGENCE_ENDPOINT=https://<resource>.cognitiveservices.azure.com
 AZURE_DOC_INTELLIGENCE_KEY=
+
+# --- Proxy ---
+# Optional HTTP(S) proxy for outbound requests
+HTTP_PROXY=
+HTTPS_PROXY=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,3 +20,7 @@ LIST_ID=
 
 # Required: comma-separated origins allowed to access the backend (e.g. http://localhost:3000)
 ALLOWED_ORIGINS=
+
+# Optional: proxy for outbound HTTP/HTTPS requests
+HTTP_PROXY=
+HTTPS_PROXY=

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -1,5 +1,16 @@
 const { z } = require('zod')
 
+const lowerHttpProxy = process.env.http_proxy
+const lowerHttpsProxy = process.env.https_proxy
+if (lowerHttpProxy && !process.env.HTTP_PROXY) {
+  process.env.HTTP_PROXY = lowerHttpProxy
+  delete process.env.http_proxy
+}
+if (lowerHttpsProxy && !process.env.HTTPS_PROXY) {
+  process.env.HTTPS_PROXY = lowerHttpsProxy
+  delete process.env.https_proxy
+}
+
 const envSchema = z.object({
   NODE_ENV: z.enum(['development', 'production']).default('development'),
   PORT: z.string().regex(/^\d+$/).default('5000'),
@@ -10,10 +21,15 @@ const envSchema = z.object({
   TENANT_ID: z.string().optional(),
   CLIENT_ID: z.string().optional(),
   AZURE_DOC_INTELLIGENCE_ENDPOINT: z.string().optional(),
-  AZURE_DOC_INTELLIGENCE_KEY: z.string().optional()
+  AZURE_DOC_INTELLIGENCE_KEY: z.string().optional(),
+  HTTP_PROXY: z.string().optional(),
+  HTTPS_PROXY: z.string().optional()
 })
 
 const parsed = envSchema.parse(process.env)
+
+if (!parsed.HTTP_PROXY && !parsed.HTTPS_PROXY)
+  console.log('HTTP(S)_PROXY not set; outgoing requests will not use a proxy')
 
 if (!parsed.DEMO_MODE) {
   if (parsed.AUTH_PROVIDER === 'local' && !parsed.JWT_SECRET)


### PR DESCRIPTION
## Summary
- handle optional HTTP(S)_PROXY env vars in backend config
- document proxy env vars in example env files

## Testing
- `npm test --prefix backend` *(fails: Expected 401 but received 400)*

------
https://chatgpt.com/codex/tasks/task_b_6898fda416708332a2336255d8298100