### PR TITLE
fix: prevent sandboxed embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ VITE_API_BASE_URL=https://backend.example.com/api
 Redirect URIs for the Azure AD app must include both your deployed origin (e.g. Vercel) and `http://localhost` for local development. Authentication uses the Authorization Code flow with PKCE via MSAL; no implicit grant is required.
 The frontend reads `VITE_MSAL_CLIENT_ID`, `VITE_MSAL_TENANT_ID` and `VITE_MSAL_REDIRECT_URI` to configure the MSAL client.
 
+MSAL relies on a hidden iframe to complete sign-in. If the app is embedded in an iframe, avoid sandboxing or drop the combination of `allow-scripts` and `allow-same-origin` so the iframe can communicate with the parent. Serving the app at the top level is recommended.
+
 ## Running in production
 
 For production builds run `npm run build` in the `frontend` directory to generate a static build in `frontend/dist`. You can then serve this folder through your preferred HTTP server (Nginx, Express, etc.). The backend can be deployed to any Node‑capable environment; just remember to set the environment variables described above.

--- a/backend/server.js
+++ b/backend/server.js
@@ -70,6 +70,11 @@ function validate(value, rule) {
 // Initialize Express
 const app = express()
 app.use(cookieParser())
+app.use((req, res, next) => {
+  res.setHeader('Content-Security-Policy', "frame-ancestors 'self'")
+  res.setHeader('X-Frame-Options', 'SAMEORIGIN')
+  next()
+})
 const MAX_FILES = 5
 const upload = multer({
   storage: multer.memoryStorage(),

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Receipt Extractor App" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="frame-ancestors 'self'"
+    />
     <title>Receipt Extractor</title>
     <script async src="https://docs.opencv.org/4.9.0/opencv.js" onload="onOpenCvReady()" type="text/javascript"></script>
     <script type="text/javascript">


### PR DESCRIPTION
## Summary
- prevent iframe embedding with CSP and frameguard headers
- document avoiding sandboxed iframes for MSAL sign-in

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_6899137f24f08332b346130217c91411